### PR TITLE
Fixing the key setting in the datastore to work with arrays

### DIFF
--- a/src/services/dataStore.ts
+++ b/src/services/dataStore.ts
@@ -47,7 +47,7 @@ export const createDataStore: CreateDataStore = async (
     },
 
     async set(key, value) {
-      await db.set(key, value).save();
+      await db.set(key instanceof Array ? key.join(".") : key, value).save();
     },
   };
 };


### PR DESCRIPTION
When creating a user pool client, the data store key is being called with a key, https://github.com/jagregory/cognito-local/blob/master/src/services/userPoolClient.ts#L102. This isn't supported by stormdb and thus the json file being created isn't quite right. It looks like `Clients,123456789`. Presumably because stormdb is turning the key into a string.
