### PR TITLE
Change auth_time resolution

### DIFF
--- a/src/services/tokens.ts
+++ b/src/services/tokens.ts
@@ -21,7 +21,7 @@ export function generateTokens(
   userPoolId: string
 ) {
   const eventId = uuid.v4();
-  const authTime = new Date().getTime();
+  const authTime = Math.floor(new Date().getTime() / 1000);
 
   return {
     AccessToken: jwt.sign(

--- a/src/targets/initiateAuth.test.ts
+++ b/src/targets/initiateAuth.test.ts
@@ -354,7 +354,7 @@ describe("InitiateAuth target", () => {
               username: "0000-0000",
               event_id: expect.stringMatching(UUID),
               scope: "aws.cognito.signin.user.admin", // TODO: scopes
-              auth_time: now.getTime(),
+              auth_time: Math.floor(now.getTime() / 1000),
               jti: expect.stringMatching(UUID),
             });
             expect(
@@ -380,7 +380,7 @@ describe("InitiateAuth target", () => {
               "cognito:username": "0000-0000",
               email_verified: true,
               event_id: expect.stringMatching(UUID),
-              auth_time: now.getTime(),
+              auth_time: Math.floor(now.getTime() / 1000),
               email: "example@example.com",
             });
             expect(
@@ -436,7 +436,7 @@ describe("InitiateAuth target", () => {
             username: "0000-0000",
             event_id: expect.stringMatching(UUID),
             scope: "aws.cognito.signin.user.admin", // TODO: scopes
-            auth_time: now.getTime(),
+            auth_time: Math.floor(now.getTime() / 1000),
             jti: expect.stringMatching(UUID),
           });
           expect(
@@ -458,7 +458,7 @@ describe("InitiateAuth target", () => {
             "cognito:username": "0000-0000",
             email_verified: true,
             event_id: expect.stringMatching(UUID),
-            auth_time: now.getTime(),
+            auth_time: Math.floor(now.getTime() / 1000),
             email: "example@example.com",
           });
           expect(

--- a/src/targets/respondToAuthChallenge.test.ts
+++ b/src/targets/respondToAuthChallenge.test.ts
@@ -108,7 +108,7 @@ describe("RespondToAuthChallenge target", () => {
         username: "0000-0000",
         event_id: expect.stringMatching(UUID),
         scope: "aws.cognito.signin.user.admin", // TODO: scopes
-        auth_time: now.getTime(),
+        auth_time: Math.floor(now.getTime() / 1000),
         jti: expect.stringMatching(UUID),
       });
       expect(
@@ -128,7 +128,7 @@ describe("RespondToAuthChallenge target", () => {
         "cognito:username": "0000-0000",
         email_verified: true,
         event_id: expect.stringMatching(UUID),
-        auth_time: now.getTime(),
+        auth_time: Math.floor(now.getTime() / 1000),
         email: "example@example.com",
       });
       expect(


### PR DESCRIPTION
From the [spec](https://openid.net/specs/openid-connect-core-1_0.html):
> auth_time
Time when the End-User authentication occurred. Its value is a JSON number representing the number of **seconds** from 1970-01-01T0:0:0Z as measured in UTC until the date/time. When a max_age request is made or when auth_time is requested as an Essential Claim, then this Claim is REQUIRED; otherwise, its inclusion is OPTIONAL. (The auth_time Claim semantically corresponds to the OpenID 2.0 PAPE [OpenID.PAPE] auth_time response parameter.)
