### PR TITLE
chore: add configuration for token issuer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea
 lib
 node_modules
+.log

--- a/README.md
+++ b/README.md
@@ -68,19 +68,20 @@ Before starting Cognito Local, create a config file:
 
 You can edit that `.cognito/config.json` and add any of the following settings:
 
-| Setting                                    | Type       | Default     | Description                                                 |
-| ------------------------------------------ | ---------- | ----------- | ----------------------------------------------------------- |
-| `LambdaClient`                             | `object`   |             | Any setting you would pass to the AWS.Lambda Node.js client |
-| `LambdaClient.credentials.accessKeyId`     | `string`   | `local`     |                                                             |
-| `LambdaClient.credentials.secretAccessKey` | `string`   | `local`     |                                                             |
-| `LambdaClient.endpoint`                    | `string`   | `local`     |                                                             |
-| `LambdaClient.region`                      | `string`   | `local`     |                                                             |
-| `TriggerFunctions`                         | `object`   | `{}`        | Trigger name to Function name mapping                       |
-| `TriggerFunctions.UserMigration`           | `string`   |             | User Migration lambda name                                  |
-| `UserPoolDefaults`                         | `object`   |             | Default behaviour to use for the User Pool                  |
-| `UserPoolDefaults.Id`                      | `string`   | `local`     | Default User Pool Id                                        |
-| `UserPoolDefaults.UsernameAttributes`      | `string[]` | `["email"]` | Username alias attributes                                   |
-| `UserPoolDefaults.MfaConfiguration`        | `string`   |             | MFA type                                                    |
+| Setting                                    | Type       | Default                 | Description                                                 |
+| ------------------------------------------ | ---------- | ----------------------- | ----------------------------------------------------------- |
+| `LambdaClient`                             | `object`   |                         | Any setting you would pass to the AWS.Lambda Node.js client |
+| `LambdaClient.credentials.accessKeyId`     | `string`   | `local`                 |                                                             |
+| `LambdaClient.credentials.secretAccessKey` | `string`   | `local`                 |                                                             |
+| `LambdaClient.endpoint`                    | `string`   | `local`                 |                                                             |
+| `LambdaClient.region`                      | `string`   | `local`                 |                                                             |
+| `TriggerFunctions`                         | `object`   | `{}`                    | Trigger name to Function name mapping                       |
+| `TriggerFunctions.UserMigration`           | `string`   |                         | User Migration lambda name                                  |
+| `UserPoolDefaults`                         | `object`   |                         | Default behaviour to use for the User Pool                  |
+| `UserPoolDefaults.Id`                      | `string`   | `local`                 | Default User Pool Id                                        |
+| `UserPoolDefaults.UsernameAttributes`      | `string[]` | `["email"]`             | Username alias attributes                                   |
+| `UserPoolDefaults.MfaConfiguration`        | `string`   |                         | MFA type                                                    |
+| `TokenConfig.IssuerDomain`                 | `string`   | `http://localhost:9229` | Issuer domain override                                      |
 
 The default config is:
 
@@ -97,6 +98,9 @@ The default config is:
   "UserPoolDefaults": {
     "Id": "local",
     "UsernameAttributes": ["email"]
+  },
+  "TokenConfig": {
+    "IssuerDomain": "http://localhost:9229"
   }
 }
 ```

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "express": "^4.17.1",
     "jsonwebtoken": "^8.5.1",
     "short-uuid": "^3.1.1",
-    "stormdb": "^0.3.0",
+    "stormdb": "^0.4.1",
     "uuid": "^7.0.3"
   },
   "nodemonConfig": {

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -2,11 +2,13 @@ import deepmerge from "deepmerge";
 import { createDataStore } from "../services/dataStore";
 import { FunctionConfig } from "../services/lambda";
 import { UserPool } from "../services/userPoolClient";
+import { TokenConfig } from "../services/tokens";
 
 export interface Config {
   LambdaClient: AWS.Lambda.ClientConfiguration;
   TriggerFunctions: FunctionConfig;
   UserPoolDefaults: UserPool;
+  TokenConfig: TokenConfig;
 }
 
 const defaults: Config = {
@@ -21,6 +23,9 @@ const defaults: Config = {
   UserPoolDefaults: {
     Id: "local",
     UsernameAttributes: ["email"],
+  },
+  TokenConfig: {
+    IssuerDomain: "http://localhost:9229",
   },
 };
 

--- a/src/services/cognitoClient.test.ts
+++ b/src/services/cognitoClient.test.ts
@@ -12,6 +12,7 @@ describe("Cognito Client", () => {
   beforeEach(() => {
     mockDataStore = {
       set: jest.fn(),
+      setValue: jest.fn(),
       get: jest.fn(),
       getRoot: jest.fn(),
     };

--- a/src/services/dataStore.ts
+++ b/src/services/dataStore.ts
@@ -9,6 +9,7 @@ export interface DataStore {
   get<T>(key: string | string[]): Promise<T | null>;
   get<T>(key: string | string[], defaultValue: T): Promise<T>;
   set<T>(key: string | string[], value: T): Promise<void>;
+  setValue<T>(value: T, pointers: string[]): Promise<void>;
 }
 
 export type CreateDataStore = (
@@ -48,6 +49,11 @@ export const createDataStore: CreateDataStore = async (
 
     async set(key, value) {
       await db.set(key, value).save();
+    },
+
+    async setValue(value, pointers) {
+      db.setValue(value, pointers);
+      await db.save();
     },
   };
 };

--- a/src/services/tokens.ts
+++ b/src/services/tokens.ts
@@ -1,7 +1,12 @@
 import jwt from "jsonwebtoken";
 import * as uuid from "uuid";
+import { loadConfig } from "../server/config";
 import PrivateKey from "../keys/cognitoLocal.private.json";
 import { User } from "./userPoolClient";
+
+export interface TokenConfig {
+  IssuerDomain?: string;
+}
 
 export interface Token {
   client_id: string;
@@ -15,13 +20,14 @@ export interface Token {
   jti: string;
 }
 
-export function generateTokens(
+export async function generateTokens(
   user: User,
   clientId: string,
   userPoolId: string
 ) {
   const eventId = uuid.v4();
   const authTime = new Date().getTime();
+  const config = await loadConfig();
 
   return {
     AccessToken: jwt.sign(
@@ -38,7 +44,7 @@ export function generateTokens(
       PrivateKey.pem,
       {
         algorithm: "RS256",
-        issuer: `http://localhost:9229/${userPoolId}`,
+        issuer: `${config.TokenConfig.IssuerDomain}/${userPoolId}`,
         expiresIn: "24h",
         keyid: "CognitoLocal",
       }

--- a/src/services/userPoolClient.test.ts
+++ b/src/services/userPoolClient.test.ts
@@ -22,11 +22,13 @@ describe("User Pool Client", () => {
 
     mockClientsDataStore = {
       set: jest.fn(),
+      setValue: jest.fn(),
       get: jest.fn(),
       getRoot: jest.fn(),
     };
     mockDataStore = {
       set: jest.fn(),
+      setValue: jest.fn(),
       get: jest.fn(),
       getRoot: jest.fn(),
     };

--- a/src/targets/adminConfirmSignUp.ts
+++ b/src/targets/adminConfirmSignUp.ts
@@ -1,0 +1,34 @@
+import { Services } from "../services";
+import { NotAuthorizedError } from "../errors";
+
+interface Input {
+  UserPoolId: string;
+  Username: string;
+}
+
+export type AdminConfirmSignUpTarget = (body: Input) => Promise<object | null>;
+
+export const AdminConfirmSignUp = ({
+  cognitoClient,
+}: Services): AdminConfirmSignUpTarget => async (body) => {
+  const { UserPoolId, Username } = body || {};
+  const userPool = await cognitoClient.getUserPool(UserPoolId);
+  const user = await userPool.getUserByUsername(Username);
+  if (!user) {
+    throw new NotAuthorizedError();
+  }
+  await userPool.saveUser({
+    ...user,
+    UserStatus: "CONFIRMED",
+    // TODO: Remove existing email_verified attribute?
+    Attributes: [
+      ...(user.Attributes || []),
+      {
+        Name: "email_verified",
+        Value: "true",
+      },
+    ],
+  });
+  // TODO: Should possibly return something?
+  return {};
+};

--- a/src/targets/adminCreateUser.ts
+++ b/src/targets/adminCreateUser.ts
@@ -1,0 +1,32 @@
+import { Services } from "../services";
+
+interface Input {
+  UserPoolId: string;
+  Username: string;
+  TemporaryPassword: string;
+  MessageAction?: string;
+  UserAttributes?: any;
+  DesiredDeliveryMediums?: any;
+}
+
+export type AdminCreateUserTarget = (body: Input) => Promise<null>;
+
+export const AdminCreateUser = ({
+  cognitoClient,
+}: Services): AdminCreateUserTarget => async (body) => {
+  const { UserPoolId, Username, TemporaryPassword, UserAttributes } =
+    body || {};
+  const userPool = await cognitoClient.getUserPool(UserPoolId);
+  await userPool.saveUser({
+    Username,
+    Password: TemporaryPassword,
+    Attributes: UserAttributes,
+    Enabled: true,
+    UserStatus: "CONFIRMED",
+    ConfirmationCode: undefined,
+    UserCreateDate: new Date().getTime(),
+    UserLastModifiedDate: new Date().getTime(),
+  });
+  // TODO: Anything to return?
+  return null;
+};

--- a/src/targets/adminCreateUser.ts
+++ b/src/targets/adminCreateUser.ts
@@ -1,4 +1,5 @@
 import { Services } from "../services";
+import { User } from "../services/userPoolClient";
 
 interface Input {
   UserPoolId: string;
@@ -9,7 +10,11 @@ interface Input {
   DesiredDeliveryMediums?: any;
 }
 
-export type AdminCreateUserTarget = (body: Input) => Promise<null>;
+interface Output {
+  User: User;
+}
+
+export type AdminCreateUserTarget = (body: Input) => Promise<User | null>;
 
 export const AdminCreateUser = ({
   cognitoClient,
@@ -17,7 +22,7 @@ export const AdminCreateUser = ({
   const { UserPoolId, Username, TemporaryPassword, UserAttributes } =
     body || {};
   const userPool = await cognitoClient.getUserPool(UserPoolId);
-  await userPool.saveUser({
+  const user: User = {
     Username,
     Password: TemporaryPassword,
     Attributes: UserAttributes,
@@ -26,7 +31,8 @@ export const AdminCreateUser = ({
     ConfirmationCode: undefined,
     UserCreateDate: new Date().getTime(),
     UserLastModifiedDate: new Date().getTime(),
-  });
-  // TODO: Anything to return?
-  return null;
+  };
+  await userPool.saveUser(user);
+  // TODO: Shuldn't return password.
+  return user;
 };

--- a/src/targets/adminDeleteUser.ts
+++ b/src/targets/adminDeleteUser.ts
@@ -1,0 +1,22 @@
+import { Services } from "../services";
+import { NotAuthorizedError } from "../errors";
+
+interface Input {
+  UserPoolId: string;
+  Username: string;
+}
+
+export type AdminDeleteUserTarget = (body: Input) => Promise<null>;
+
+export const AdminDeleteUser = ({
+  cognitoClient,
+}: Services): AdminDeleteUserTarget => async (body) => {
+  const { UserPoolId, Username } = body || {};
+  const userPool = await cognitoClient.getUserPool(UserPoolId);
+  const user = await userPool.getUserByUsername(Username);
+  if (!user) {
+    throw new NotAuthorizedError();
+  }
+  // TODO
+  return null;
+};

--- a/src/targets/adminGetUser.ts
+++ b/src/targets/adminGetUser.ts
@@ -1,0 +1,27 @@
+import { Services } from "../services";
+import { NotAuthorizedError } from "../errors";
+
+interface Input {
+  UserPoolId: string;
+  Username: string;
+}
+
+interface Output {
+  UserAttributes: any;
+}
+
+export type AdminGetUserTarget = (body: Input) => Promise<Output | null>;
+
+export const AdminGetUser = ({
+  cognitoClient,
+}: Services): AdminGetUserTarget => async (body) => {
+  const { UserPoolId, Username } = body || {};
+  const userPool = await cognitoClient.getUserPool(UserPoolId);
+  const user = await userPool.getUserByUsername(Username);
+  if (!user) {
+    throw new NotAuthorizedError();
+  }
+  return {
+    UserAttributes: user.Attributes,
+  };
+};

--- a/src/targets/adminUpdateUserAttributes.ts
+++ b/src/targets/adminUpdateUserAttributes.ts
@@ -4,26 +4,28 @@ import { NotAuthorizedError } from "../errors";
 interface Input {
   UserPoolId: string;
   Username: string;
-}
-
-interface Output {
-  UserStatus: string;
   UserAttributes: any;
 }
 
-export type AdminGetUserTarget = (body: Input) => Promise<Output | null>;
+interface Output {
+  UserAttributes: any;
+}
 
-export const AdminGetUser = ({
+export type AdminUpdateUserAttributesTarget = (
+  body: Input
+) => Promise<Output | null>;
+
+export const AdminUpdateUserAttributes = ({
   cognitoClient,
-}: Services): AdminGetUserTarget => async (body) => {
+}: Services): AdminUpdateUserAttributesTarget => async (body) => {
   const { UserPoolId, Username } = body || {};
   const userPool = await cognitoClient.getUserPool(UserPoolId);
   const user = await userPool.getUserByUsername(Username);
   if (!user) {
     throw new NotAuthorizedError();
   }
+  // TODO: Should save the attributes.
   return {
-    UserStatus: user.UserStatus,
     UserAttributes: user.Attributes,
   };
 };

--- a/src/targets/changePassword.ts
+++ b/src/targets/changePassword.ts
@@ -1,0 +1,31 @@
+import jwt from "jsonwebtoken";
+import { Services } from "../services";
+import { NotAuthorizedError } from "../errors";
+
+interface Input {
+  AccessToken: string;
+  PreviousPassword: string;
+  ProposedPassword: string;
+}
+
+export type ChangePasswordTarget = (body: Input) => Promise<object | null>;
+
+export const ChangePassword = ({
+  cognitoClient,
+}: Services): ChangePasswordTarget => async (body) => {
+  const { AccessToken, PreviousPassword, ProposedPassword } = body || {};
+  const claims = jwt.decode(AccessToken) as any;
+  const userPool = await cognitoClient.getUserPoolForClientId(claims.client_id);
+  const user = await userPool.getUserByUsername(claims.username);
+  if (!user) {
+    throw new NotAuthorizedError();
+  }
+  // TODO: Should check previous password.
+  await userPool.saveUser({
+    ...user,
+    Password: ProposedPassword,
+    UserLastModifiedDate: new Date().getTime(),
+  });
+  // TODO: Should possibly return something?
+  return {};
+};

--- a/src/targets/initiateAuth.ts
+++ b/src/targets/initiateAuth.ts
@@ -83,14 +83,18 @@ const verifyMfaChallenge = async (
   };
 };
 
-const verifyPasswordChallenge = (
+const verifyPasswordChallenge = async (
   user: User,
   body: Input,
   userPool: UserPoolClient
-): PasswordVerifierOutput => ({
+): Promise<PasswordVerifierOutput> => ({
   ChallengeName: "PASSWORD_VERIFIER",
   ChallengeParameters: {},
-  AuthenticationResult: generateTokens(user, body.ClientId, userPool.config.Id),
+  AuthenticationResult: await generateTokens(
+    user,
+    body.ClientId,
+    userPool.config.Id
+  ),
   Session: body.Session,
 });
 
@@ -139,5 +143,5 @@ export const InitiateAuth = ({
     return verifyMfaChallenge(user, body, userPool, codeDelivery);
   }
 
-  return verifyPasswordChallenge(user, body, userPool);
+  return await verifyPasswordChallenge(user, body, userPool);
 };

--- a/src/targets/respondToAuthChallenge.ts
+++ b/src/targets/respondToAuthChallenge.ts
@@ -48,7 +48,7 @@ export const RespondToAuthChallenge = ({
   return {
     ChallengeName: body.ChallengeName,
     ChallengeParameters: {},
-    AuthenticationResult: generateTokens(
+    AuthenticationResult: await generateTokens(
       user,
       body.ClientId,
       userPool.config.Id

--- a/src/targets/router.ts
+++ b/src/targets/router.ts
@@ -9,6 +9,9 @@ import { ListUsers } from "./listUsers";
 import { RespondToAuthChallenge } from "./respondToAuthChallenge";
 import { SignUp } from "./signUp";
 import { GetUser } from "./getUser";
+import { AdminCreateUser } from "./adminCreateUser";
+import { AdminGetUser } from "./adminGetUser";
+import { AdminDeleteUser } from "./adminDeleteUser";
 
 export const Targets = {
   ConfirmForgotPassword,
@@ -20,6 +23,9 @@ export const Targets = {
   RespondToAuthChallenge,
   SignUp,
   GetUser,
+  AdminCreateUser,
+  AdminGetUser,
+  AdminDeleteUser,
 };
 
 type TargetName = keyof typeof Targets;

--- a/src/targets/router.ts
+++ b/src/targets/router.ts
@@ -4,6 +4,7 @@ import { ConfirmForgotPassword } from "./confirmForgotPassword";
 import { ConfirmSignUp } from "./confirmSignUp";
 import { CreateUserPoolClient } from "./createUserPoolClient";
 import { ForgotPassword } from "./forgotPassword";
+import { ChangePassword } from "./changePassword";
 import { InitiateAuth } from "./initiateAuth";
 import { ListUsers } from "./listUsers";
 import { RespondToAuthChallenge } from "./respondToAuthChallenge";
@@ -12,12 +13,15 @@ import { GetUser } from "./getUser";
 import { AdminCreateUser } from "./adminCreateUser";
 import { AdminGetUser } from "./adminGetUser";
 import { AdminDeleteUser } from "./adminDeleteUser";
+import { AdminConfirmSignUp } from "./adminConfirmSignUp";
+import { AdminUpdateUserAttributes } from "./adminUpdateUserAttributes";
 
 export const Targets = {
   ConfirmForgotPassword,
   ConfirmSignUp,
   CreateUserPoolClient,
   ForgotPassword,
+  ChangePassword,
   InitiateAuth,
   ListUsers,
   RespondToAuthChallenge,
@@ -26,6 +30,8 @@ export const Targets = {
   AdminCreateUser,
   AdminGetUser,
   AdminDeleteUser,
+  AdminConfirmSignUp,
+  AdminUpdateUserAttributes,
 };
 
 type TargetName = keyof typeof Targets;

--- a/src/targets/signUp.ts
+++ b/src/targets/signUp.ts
@@ -43,7 +43,9 @@ export const SignUp = ({
     UserCreateDate: new Date().getTime(),
     UserLastModifiedDate: new Date().getTime(),
     UserStatus: "UNCONFIRMED",
-    Username: uuid.v4(),
+    // TODO: Why was this here?
+    // Username: uuid.v4(),
+    Username: body.Username,
   };
 
   const deliveryDetails: DeliveryDetails = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8806,10 +8806,10 @@ stealthy-require@^1.1.1:
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
 
-stormdb@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/stormdb/-/stormdb-0.3.0.tgz#7ecdffbf8f59709508e7126c1d581ea866749476"
-  integrity sha512-cpziMPVMlyizwlkryn5h8FD9rj3RezZ0PAOj2Skj+48Mdv1fJffjOO2xzlGSNisseUVhxRsrfPL/H4P06n3fBQ==
+stormdb@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/stormdb/-/stormdb-0.4.1.tgz#00e0049da6408eacace5a3e97a54cb3fbb035cdd"
+  integrity sha512-syYUq/lhwT82HZSyHFsy1kqV6ibLIJWEg55O2rHfxW87MS16zhIK7tanhfC2Ihz1So5bgZxrqultLIgisGf74w==
 
 stream-combiner2@~1.1.1:
   version "1.1.1"


### PR DESCRIPTION
Added a configuration option to specify the issuer encoded into tokens. I found this was needed to support running in Docker with a suite of other services on the Docker network.