### PR TITLE
refactor: the log is actually a service, so promote it to being one

### DIFF
--- a/src/__tests__/mockLogger.ts
+++ b/src/__tests__/mockLogger.ts
@@ -1,4 +1,4 @@
-import { Logger } from "../log";
+import { LogService } from "../services/LogService";
 
 export const MockLogger = {
   info: jest.fn(),
@@ -8,4 +8,4 @@ export const MockLogger = {
   child() {
     return this;
   },
-} as Logger;
+} as LogService;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,5 +1,5 @@
 import { Response } from "express";
-import { Logger } from "./log";
+import { LogService } from "./services/LogService";
 
 export class UnsupportedError extends Error {}
 
@@ -84,7 +84,11 @@ export class InvalidParameterError extends CognitoError {
   }
 }
 
-export const unsupported = (message: string, res: Response, logger: Logger) => {
+export const unsupported = (
+  message: string,
+  res: Response,
+  logger: LogService
+) => {
   logger.error(`Cognito Local unsupported feature: ${message}`);
   return res.status(500).json({
     code: "CognitoLocal#Unsupported",

--- a/src/services/LogService.ts
+++ b/src/services/LogService.ts
@@ -1,7 +1,7 @@
 import pino from "pino";
 
-export type Logger = {
-  child(bindings: pino.Bindings, options?: pino.ChildLoggerOptions): Logger;
+export type LogService = {
+  child(bindings: pino.Bindings, options?: pino.ChildLoggerOptions): LogService;
   debug: pino.LogFn;
   error: pino.LogFn;
   info: pino.LogFn;

--- a/src/services/context.ts
+++ b/src/services/context.ts
@@ -1,5 +1,5 @@
-import { Logger } from "../log";
+import { LogService } from "./LogService";
 
 export interface Context {
-  readonly logger: Logger;
+  readonly logger: LogService;
 }

--- a/src/targets/router.ts
+++ b/src/targets/router.ts
@@ -1,4 +1,4 @@
-import { Logger } from "../log";
+import { LogService } from "../services/LogService";
 import { Services } from "../services";
 import { UnsupportedError } from "../errors";
 import { AdminDeleteUserAttributes } from "./adminDeleteUserAttributes";
@@ -65,7 +65,7 @@ export const Targets = {
 
 type TargetName = keyof typeof Targets;
 
-export type Context = { readonly logger: Logger };
+export type Context = { readonly logger: LogService };
 export type Target<Req extends {}, Res extends {}> = (
   ctx: Context,
   req: Req


### PR DESCRIPTION
It makes sense to call the LogService a service since it actually is one in all but code structure. So I refactored this and all the imports