### PR TITLE
fix: confirmation ode from 4-digit to 6-digit

### DIFF
--- a/integration-tests/userPoolService.test.ts
+++ b/integration-tests/userPoolService.test.ts
@@ -94,7 +94,7 @@ describe("User Pool Service", () => {
           Username: username,
           Password: "hunter3",
           UserStatus: "UNCONFIRMED",
-          ConfirmationCode: "1234",
+          ConfirmationCode: "123456",
           Attributes: [
             { Name: "sub", Value: "uuid-1234" },
             { Name: "email", Value: "example@example.com" },
@@ -114,7 +114,7 @@ describe("User Pool Service", () => {
             Username: username,
             Password: "hunter3",
             UserStatus: "UNCONFIRMED",
-            ConfirmationCode: "1234",
+            ConfirmationCode: "123456",
             Attributes: [
               { Name: "sub", Value: "uuid-1234" },
               { Name: "email", Value: "example@example.com" },

--- a/src/services/messageDelivery/consoleMessageSender.test.ts
+++ b/src/services/messageDelivery/consoleMessageSender.test.ts
@@ -14,7 +14,7 @@ describe("consoleMessageSender", () => {
   describe.each(["sendEmail", "sendSms"] as const)("%s", (fn) => {
     it("prints the message to the console", async () => {
       await sender[fn](TestContext, user, destination, {
-        __code: "1234",
+        __code: "123456",
       });
 
       expect(TestContext.logger.info).toHaveBeenCalledWith(
@@ -24,13 +24,13 @@ describe("consoleMessageSender", () => {
         expect.stringMatching(/Destination:\s+example@example.com/)
       );
       expect(TestContext.logger.info).toHaveBeenCalledWith(
-        expect.stringMatching(/Code:\s+1234/)
+        expect.stringMatching(/Code:\s+123456/)
       );
     });
 
     it("doesn't print undefined fields", async () => {
       await sender[fn](TestContext, user, destination, {
-        __code: "1234",
+        __code: "123456",
         emailMessage: undefined,
       });
 
@@ -41,7 +41,7 @@ describe("consoleMessageSender", () => {
 
     it("prints additional fields", async () => {
       await sender[fn](TestContext, user, destination, {
-        __code: "1234",
+        __code: "123456",
         emailMessage: "this is the email message",
       });
 

--- a/src/services/messages.test.ts
+++ b/src/services/messages.test.ts
@@ -53,7 +53,7 @@ describe("messages service", () => {
             "clientId",
             "userPoolId",
             user,
-            "1234",
+            "123456",
             {
               client: "metadata",
             },
@@ -65,7 +65,7 @@ describe("messages service", () => {
             clientMetadata: {
               client: "metadata",
             },
-            code: "1234",
+            code: "123456",
             source: `CustomMessage_${source}`,
             userAttributes: user.Attributes,
             userPoolId: "userPoolId",
@@ -77,7 +77,7 @@ describe("messages service", () => {
             user,
             deliveryDetails,
             {
-              __code: "1234",
+              __code: "123456",
               emailMessage: "email",
               emailSubject: "email subject",
               smsMessage: "sms",
@@ -103,7 +103,7 @@ describe("messages service", () => {
             "clientId",
             "userPoolId",
             user,
-            "1234",
+            "123456",
             {
               client: "metadata",
             },
@@ -115,7 +115,7 @@ describe("messages service", () => {
             clientMetadata: {
               client: "metadata",
             },
-            code: "1234",
+            code: "123456",
             source: `CustomMessage_${source}`,
             userAttributes: user.Attributes,
             userPoolId: "userPoolId",
@@ -127,7 +127,7 @@ describe("messages service", () => {
             user,
             deliveryDetails,
             {
-              __code: "1234",
+              __code: "123456",
             }
           );
         });
@@ -145,7 +145,7 @@ describe("messages service", () => {
           "clientId",
           "userPoolId",
           user,
-          "1234",
+          "123456",
           {
             client: "metadata",
           },
@@ -158,7 +158,7 @@ describe("messages service", () => {
           user,
           deliveryDetails,
           {
-            __code: "1234",
+            __code: "123456",
           }
         );
       });

--- a/src/services/otp.test.ts
+++ b/src/services/otp.test.ts
@@ -2,6 +2,6 @@ import { otp } from "./otp";
 
 describe("otp", () => {
   it("generates a code", () => {
-    expect(otp()).toMatch(/^[0-9]{4}$/);
+    expect(otp()).toMatch(/^[0-9]{6}$/);
   });
 });

--- a/src/services/otp.ts
+++ b/src/services/otp.ts
@@ -1,4 +1,4 @@
 export const otp = (): string =>
-  Math.floor(Math.random() * 9999)
+  Math.floor(Math.random() * 999999)
     .toString()
-    .padStart(4, "0");
+    .padStart(6, "0");

--- a/src/services/triggers/customMessage.test.ts
+++ b/src/services/triggers/customMessage.test.ts
@@ -21,7 +21,7 @@ describe("CustomMessage trigger", () => {
       const message = await customMessage(TestContext, {
         clientId: "clientId",
         clientMetadata: undefined,
-        code: "1234",
+        code: "123456",
         source: "CustomMessage_ForgotPassword",
         userAttributes: [],
         username: "username",
@@ -45,7 +45,7 @@ describe("CustomMessage trigger", () => {
         clientMetadata: {
           client: "metadata",
         },
-        code: "1234",
+        code: "123456",
         source: "CustomMessage_ForgotPassword",
         userAttributes: [{ Name: "user", Value: "attribute" }],
         username: "example@example.com",
@@ -73,11 +73,11 @@ describe("CustomMessage trigger", () => {
 
       expect(message).not.toBeNull();
       expect(message?.emailMessage).toEqual(
-        "hi example@example.com your code is 1234. via email"
+        "hi example@example.com your code is 123456. via email"
       );
       expect(message?.emailSubject).toEqual("email subject");
       expect(message?.smsMessage).toEqual(
-        "hi example@example.com your code is 1234. via sms"
+        "hi example@example.com your code is 123456. via sms"
       );
     });
   });

--- a/src/targets/adminUpdateUserAttributes.test.ts
+++ b/src/targets/adminUpdateUserAttributes.test.ts
@@ -30,7 +30,7 @@ describe("AdminUpdateUserAttributes target", () => {
       clock,
       cognito: newMockCognitoService(mockUserPoolService),
       messages: mockMessages,
-      otp: () => "1234",
+      otp: () => "123456",
     });
   });
 
@@ -232,7 +232,7 @@ describe("AdminUpdateUserAttributes target", () => {
             null,
             "test",
             user,
-            "1234",
+            "123456",
             { client: "metadata" },
             {
               AttributeName: "email",
@@ -244,7 +244,7 @@ describe("AdminUpdateUserAttributes target", () => {
           expect(mockUserPoolService.saveUser).toHaveBeenCalledWith(
             TestContext,
             expect.objectContaining({
-              AttributeVerificationCode: "1234",
+              AttributeVerificationCode: "123456",
             })
           );
         });

--- a/src/targets/confirmForgotPassword.test.ts
+++ b/src/targets/confirmForgotPassword.test.ts
@@ -40,7 +40,7 @@ describe("ConfirmForgotPassword target", () => {
       confirmForgotPassword(TestContext, {
         ClientId: "clientId",
         Username: "janice",
-        ConfirmationCode: "1234",
+        ConfirmationCode: "123456",
         Password: "newPassword",
       })
     ).rejects.toBeInstanceOf(UserNotFoundError);
@@ -48,7 +48,7 @@ describe("ConfirmForgotPassword target", () => {
 
   it("throws if confirmation code doesn't match stored value", async () => {
     const user = TDB.user({
-      ConfirmationCode: "4567",
+      ConfirmationCode: "456789",
       UserStatus: "UNCONFIRMED",
     });
 
@@ -58,7 +58,7 @@ describe("ConfirmForgotPassword target", () => {
       confirmForgotPassword(TestContext, {
         ClientId: "clientId",
         Username: "janice",
-        ConfirmationCode: "1234",
+        ConfirmationCode: "123456",
         Password: "newPassword",
       })
     ).rejects.toBeInstanceOf(CodeMismatchError);
@@ -67,7 +67,7 @@ describe("ConfirmForgotPassword target", () => {
   describe("when code matches", () => {
     it("updates the user's password", async () => {
       const user = TDB.user({
-        ConfirmationCode: "4567",
+        ConfirmationCode: "456789",
         UserStatus: "UNCONFIRMED",
       });
 
@@ -79,7 +79,7 @@ describe("ConfirmForgotPassword target", () => {
       await confirmForgotPassword(TestContext, {
         ClientId: "clientId",
         Username: user.Username,
-        ConfirmationCode: "4567",
+        ConfirmationCode: "456789",
         Password: "newPassword",
       });
 
@@ -97,7 +97,7 @@ describe("ConfirmForgotPassword target", () => {
         mockTriggers.enabled.mockReturnValue(true);
 
         const user = TDB.user({
-          ConfirmationCode: "4567",
+          ConfirmationCode: "456789",
           UserStatus: "UNCONFIRMED",
         });
 
@@ -109,7 +109,7 @@ describe("ConfirmForgotPassword target", () => {
             client: "metadata",
           },
           Username: user.Username,
-          ConfirmationCode: "4567",
+          ConfirmationCode: "456789",
           Password: "newPassword",
         });
 
@@ -137,7 +137,7 @@ describe("ConfirmForgotPassword target", () => {
         mockTriggers.enabled.mockReturnValue(false);
 
         const user = TDB.user({
-          ConfirmationCode: "4567",
+          ConfirmationCode: "456789",
           UserStatus: "UNCONFIRMED",
         });
 
@@ -146,7 +146,7 @@ describe("ConfirmForgotPassword target", () => {
         await confirmForgotPassword(TestContext, {
           ClientId: "clientId",
           Username: user.Username,
-          ConfirmationCode: "4567",
+          ConfirmationCode: "456789",
           Password: "newPassword",
         });
 

--- a/src/targets/confirmSignUp.test.ts
+++ b/src/targets/confirmSignUp.test.ts
@@ -36,7 +36,7 @@ describe("ConfirmSignUp target", () => {
       confirmSignUp(TestContext, {
         ClientId: "clientId",
         Username: "janice",
-        ConfirmationCode: "1234",
+        ConfirmationCode: "123456",
         ForceAliasCreation: false,
       })
     ).rejects.toBeInstanceOf(NotAuthorizedError);
@@ -44,7 +44,7 @@ describe("ConfirmSignUp target", () => {
 
   it("throws if confirmation code doesn't match stored value", async () => {
     const user = TDB.user({
-      ConfirmationCode: "4567",
+      ConfirmationCode: "456789",
       UserStatus: "UNCONFIRMED",
     });
 
@@ -54,7 +54,7 @@ describe("ConfirmSignUp target", () => {
       confirmSignUp(TestContext, {
         ClientId: "clientId",
         Username: user.Username,
-        ConfirmationCode: "1234",
+        ConfirmationCode: "123456",
       })
     ).rejects.toBeInstanceOf(CodeMismatchError);
   });
@@ -62,7 +62,7 @@ describe("ConfirmSignUp target", () => {
   describe("when code matches", () => {
     it("updates the user's confirmed status", async () => {
       const user = TDB.user({
-        ConfirmationCode: "4567",
+        ConfirmationCode: "456789",
         UserStatus: "UNCONFIRMED",
       });
 
@@ -74,7 +74,7 @@ describe("ConfirmSignUp target", () => {
       await confirmSignUp(TestContext, {
         ClientId: "clientId",
         Username: user.Username,
-        ConfirmationCode: "4567",
+        ConfirmationCode: "456789",
       });
 
       expect(mockUserPoolService.saveUser).toHaveBeenCalledWith(TestContext, {
@@ -90,7 +90,7 @@ describe("ConfirmSignUp target", () => {
         mockTriggers.enabled.mockReturnValue(true);
 
         const user = TDB.user({
-          ConfirmationCode: "4567",
+          ConfirmationCode: "456789",
           UserStatus: "UNCONFIRMED",
         });
 
@@ -102,7 +102,7 @@ describe("ConfirmSignUp target", () => {
             client: "metadata",
           },
           Username: "janice",
-          ConfirmationCode: "4567",
+          ConfirmationCode: "456789",
           ForceAliasCreation: false,
         });
 
@@ -130,7 +130,7 @@ describe("ConfirmSignUp target", () => {
         mockTriggers.enabled.mockReturnValue(false);
 
         const user = TDB.user({
-          ConfirmationCode: "4567",
+          ConfirmationCode: "456789",
           UserStatus: "UNCONFIRMED",
         });
 
@@ -139,7 +139,7 @@ describe("ConfirmSignUp target", () => {
         await confirmSignUp(TestContext, {
           ClientId: "clientId",
           Username: user.Username,
-          ConfirmationCode: "4567",
+          ConfirmationCode: "456789",
         });
 
         expect(mockTriggers.postConfirmation).not.toHaveBeenCalled();

--- a/src/targets/forgotPassword.test.ts
+++ b/src/targets/forgotPassword.test.ts
@@ -20,7 +20,7 @@ describe("ForgotPassword target", () => {
   beforeEach(() => {
     mockUserPoolService = newMockUserPoolService();
     mockMessages = newMockMessages();
-    mockOtp = jest.fn().mockReturnValue("1234");
+    mockOtp = jest.fn().mockReturnValue("123456");
     forgotPassword = ForgotPassword({
       cognito: newMockCognitoService(mockUserPoolService),
       clock: new ClockFake(currentDate),
@@ -57,7 +57,7 @@ describe("ForgotPassword target", () => {
       "clientId",
       "test",
       user,
-      "1234",
+      "123456",
       { client: "metadata" },
       {
         AttributeName: "email",
@@ -88,7 +88,7 @@ describe("ForgotPassword target", () => {
     expect(mockUserPoolService.saveUser).toHaveBeenCalledWith(TestContext, {
       ...user,
       UserLastModifiedDate: currentDate,
-      ConfirmationCode: "1234",
+      ConfirmationCode: "123456",
     });
   });
 });

--- a/src/targets/getUserAttributeVerificationCode.test.ts
+++ b/src/targets/getUserAttributeVerificationCode.test.ts
@@ -48,7 +48,7 @@ describe("GetUserAttributeVerificationCode target", () => {
     getUserAttributeVerificationCode = GetUserAttributeVerificationCode({
       cognito: newMockCognitoService(mockUserPoolService),
       messages: mockMessages,
-      otp: () => "1234",
+      otp: () => "123456",
     });
   });
 
@@ -115,7 +115,7 @@ describe("GetUserAttributeVerificationCode target", () => {
       null,
       "test",
       user,
-      "1234",
+      "123456",
       { client: "metadata" },
       {
         AttributeName: "email",
@@ -127,7 +127,7 @@ describe("GetUserAttributeVerificationCode target", () => {
     expect(mockUserPoolService.saveUser).toHaveBeenCalledWith(
       TestContext,
       expect.objectContaining({
-        AttributeVerificationCode: "1234",
+        AttributeVerificationCode: "123456",
       })
     );
   });

--- a/src/targets/initiateAuth.test.ts
+++ b/src/targets/initiateAuth.test.ts
@@ -28,7 +28,7 @@ describe("InitiateAuth target", () => {
   beforeEach(() => {
     mockUserPoolService = newMockUserPoolService();
     mockMessages = newMockMessages();
-    mockOtp = jest.fn().mockReturnValue("1234");
+    mockOtp = jest.fn().mockReturnValue("123456");
     mockTriggers = newMockTriggers();
     mockTokenGenerator = newMockTokenGenerator();
     initiateAuth = InitiateAuth({
@@ -194,7 +194,7 @@ describe("InitiateAuth target", () => {
               "clientId",
               "test",
               user,
-              "1234",
+              "123456",
               undefined,
               {
                 AttributeName: "phone_number",
@@ -208,7 +208,7 @@ describe("InitiateAuth target", () => {
               TestContext,
               {
                 ...user,
-                MFACode: "1234",
+                MFACode: "123456",
               }
             );
           });
@@ -302,7 +302,7 @@ describe("InitiateAuth target", () => {
               "clientId",
               "test",
               user,
-              "1234",
+              "123456",
               {
                 client: "metadata",
               },
@@ -318,7 +318,7 @@ describe("InitiateAuth target", () => {
               TestContext,
               {
                 ...user,
-                MFACode: "1234",
+                MFACode: "123456",
               }
             );
           });

--- a/src/targets/respondToAuthChallenge.test.ts
+++ b/src/targets/respondToAuthChallenge.test.ts
@@ -48,7 +48,7 @@ describe("RespondToAuthChallenge target", () => {
         ChallengeName: "SMS_MFA",
         ChallengeResponses: {
           USERNAME: "username",
-          SMS_MFA_CODE: "1234",
+          SMS_MFA_CODE: "123456",
         },
         Session: "Session",
       })
@@ -98,7 +98,7 @@ describe("RespondToAuthChallenge target", () => {
 
   describe("ChallengeName=SMS_MFA", () => {
     const user = TDB.user({
-      MFACode: "1234",
+      MFACode: "123456",
     });
 
     beforeEach(() => {
@@ -114,7 +114,7 @@ describe("RespondToAuthChallenge target", () => {
           ChallengeName: "SMS_MFA",
           ChallengeResponses: {
             USERNAME: user.Username,
-            SMS_MFA_CODE: "1234",
+            SMS_MFA_CODE: "123456",
           },
           Session: "Session",
         });
@@ -138,7 +138,7 @@ describe("RespondToAuthChallenge target", () => {
           ChallengeName: "SMS_MFA",
           ChallengeResponses: {
             USERNAME: user.Username,
-            SMS_MFA_CODE: "1234",
+            SMS_MFA_CODE: "123456",
           },
           Session: "Session",
           ClientMetadata: {
@@ -178,7 +178,7 @@ describe("RespondToAuthChallenge target", () => {
             },
             ChallengeResponses: {
               USERNAME: user.Username,
-              SMS_MFA_CODE: "1234",
+              SMS_MFA_CODE: "123456",
             },
             Session: "Session",
           });

--- a/src/targets/signUp.test.ts
+++ b/src/targets/signUp.test.ts
@@ -417,7 +417,7 @@ describe("SignUp target", () => {
 
       it("does not send a confirmation code", async () => {
         mockUserPoolService.getUserByUsername.mockResolvedValue(null);
-        mockOtp.mockReturnValue("1234");
+        mockOtp.mockReturnValue("123456");
 
         await signUp(TestContext, {
           ClientId: "clientId",
@@ -440,7 +440,7 @@ describe("SignUp target", () => {
 
       it("sends a confirmation code to the user's email address", async () => {
         mockUserPoolService.getUserByUsername.mockResolvedValue(null);
-        mockOtp.mockReturnValue("1234");
+        mockOtp.mockReturnValue("123456");
 
         await signUp(TestContext, {
           ClientId: "clientId",
@@ -472,7 +472,7 @@ describe("SignUp target", () => {
           "clientId",
           "test",
           createdUser,
-          "1234",
+          "123456",
           {
             client: "metadata",
           },
@@ -509,7 +509,7 @@ describe("SignUp target", () => {
 
       it("sends a confirmation code to the user's phone number", async () => {
         mockUserPoolService.getUserByUsername.mockResolvedValue(null);
-        mockOtp.mockReturnValue("1234");
+        mockOtp.mockReturnValue("123456");
 
         await signUp(TestContext, {
           ClientId: "clientId",
@@ -541,7 +541,7 @@ describe("SignUp target", () => {
           "clientId",
           "test",
           createdUser,
-          "1234",
+          "123456",
           {
             client: "metadata",
           },
@@ -581,7 +581,7 @@ describe("SignUp target", () => {
 
       it("sends a confirmation code to the user's phone number if they have both attributes", async () => {
         mockUserPoolService.getUserByUsername.mockResolvedValue(null);
-        mockOtp.mockReturnValue("1234");
+        mockOtp.mockReturnValue("123456");
 
         await signUp(TestContext, {
           ClientId: "clientId",
@@ -617,7 +617,7 @@ describe("SignUp target", () => {
           "clientId",
           "test",
           createdUser,
-          "1234",
+          "123456",
           {
             client: "metadata",
           },
@@ -631,7 +631,7 @@ describe("SignUp target", () => {
 
       it("sends a confirmation code to the user's email if they only have an email", async () => {
         mockUserPoolService.getUserByUsername.mockResolvedValue(null);
-        mockOtp.mockReturnValue("1234");
+        mockOtp.mockReturnValue("123456");
 
         await signUp(TestContext, {
           ClientId: "clientId",
@@ -663,7 +663,7 @@ describe("SignUp target", () => {
           "clientId",
           "test",
           createdUser,
-          "1234",
+          "123456",
           {
             client: "metadata",
           },
@@ -696,7 +696,7 @@ describe("SignUp target", () => {
 
   it("saves the confirmation code on the user for comparison when confirming", async () => {
     mockUserPoolService.getUserByUsername.mockResolvedValue(null);
-    mockOtp.mockReturnValue("1234");
+    mockOtp.mockReturnValue("123456");
 
     await signUp(TestContext, {
       ClientId: "clientId",
@@ -710,7 +710,7 @@ describe("SignUp target", () => {
         { Name: "sub", Value: expect.stringMatching(UUID) },
         { Name: "email", Value: "example@example.com" },
       ],
-      ConfirmationCode: "1234",
+      ConfirmationCode: "123456",
       Enabled: true,
       Password: "pwd",
       UserCreateDate: now,

--- a/src/targets/updateUserAttributes.test.ts
+++ b/src/targets/updateUserAttributes.test.ts
@@ -53,7 +53,7 @@ describe("UpdateUserAttributes target", () => {
       clock,
       cognito: newMockCognitoService(mockUserPoolService),
       messages: mockMessages,
-      otp: () => "1234",
+      otp: () => "123456",
     });
   });
 
@@ -262,7 +262,7 @@ describe("UpdateUserAttributes target", () => {
             null,
             "test",
             user,
-            "1234",
+            "123456",
             { client: "metadata" },
             {
               AttributeName: "email",
@@ -274,7 +274,7 @@ describe("UpdateUserAttributes target", () => {
           expect(mockUserPoolService.saveUser).toHaveBeenCalledWith(
             TestContext,
             expect.objectContaining({
-              AttributeVerificationCode: "1234",
+              AttributeVerificationCode: "123456",
             })
           );
         });

--- a/src/targets/verifyUserAttribute.test.ts
+++ b/src/targets/verifyUserAttribute.test.ts
@@ -54,7 +54,7 @@ describe("VerifyUserAttribute target", () => {
 
   it("verifies the user's email", async () => {
     const user = TDB.user({
-      AttributeVerificationCode: "1234",
+      AttributeVerificationCode: "123456",
     });
 
     mockUserPoolService.getUserByUsername.mockResolvedValue(user);
@@ -62,7 +62,7 @@ describe("VerifyUserAttribute target", () => {
     await verifyUserAttribute(TestContext, {
       AccessToken: validToken,
       AttributeName: "email",
-      Code: "1234",
+      Code: "123456",
     });
 
     expect(mockUserPoolService.saveUser).toHaveBeenCalledWith(TestContext, {
@@ -77,7 +77,7 @@ describe("VerifyUserAttribute target", () => {
 
   it("verifies the user's phone_number", async () => {
     const user = TDB.user({
-      AttributeVerificationCode: "1234",
+      AttributeVerificationCode: "123456",
     });
 
     mockUserPoolService.getUserByUsername.mockResolvedValue(user);
@@ -85,7 +85,7 @@ describe("VerifyUserAttribute target", () => {
     await verifyUserAttribute(TestContext, {
       AccessToken: validToken,
       AttributeName: "phone_number",
-      Code: "1234",
+      Code: "123456",
     });
 
     expect(mockUserPoolService.saveUser).toHaveBeenCalledWith(TestContext, {
@@ -100,7 +100,7 @@ describe("VerifyUserAttribute target", () => {
 
   it("does nothing for other attributes", async () => {
     const user = TDB.user({
-      AttributeVerificationCode: "1234",
+      AttributeVerificationCode: "123456",
     });
 
     mockUserPoolService.getUserByUsername.mockResolvedValue(user);
@@ -108,7 +108,7 @@ describe("VerifyUserAttribute target", () => {
     await verifyUserAttribute(TestContext, {
       AccessToken: validToken,
       AttributeName: "something else",
-      Code: "1234",
+      Code: "123456",
     });
 
     expect(mockUserPoolService.saveUser).not.toHaveBeenCalled();
@@ -119,7 +119,7 @@ describe("VerifyUserAttribute target", () => {
       verifyUserAttribute(TestContext, {
         AccessToken: "blah",
         AttributeName: "email",
-        Code: "1234",
+        Code: "123456",
       })
     ).rejects.toBeInstanceOf(InvalidParameterError);
   });
@@ -131,7 +131,7 @@ describe("VerifyUserAttribute target", () => {
       verifyUserAttribute(TestContext, {
         AccessToken: validToken,
         AttributeName: "email",
-        Code: "1234",
+        Code: "123456",
       })
     ).rejects.toEqual(new NotAuthorizedError());
   });
@@ -146,7 +146,7 @@ describe("VerifyUserAttribute target", () => {
       verifyUserAttribute(TestContext, {
         AccessToken: validToken,
         AttributeName: "email",
-        Code: "1234",
+        Code: "123456",
       })
     ).rejects.toEqual(new CodeMismatchError());
   });


### PR DESCRIPTION
based from https://github.com/jagregory/cognito-local/issues/192.
With this modification, ConfirmationCode can be generated with 6 digits by default.

I have modified the test code as well, but if it is incomplete, 
I will close this PR once. Then create a new PR with only otp.ts modified.