### PR TITLE
fix(InitiateAuth): handle UNCONFIRMED user login attempt

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -45,6 +45,12 @@ export class PasswordResetRequiredError extends CognitoError {
   }
 }
 
+export class UserNotConfirmedException extends CognitoError {
+  public constructor() {
+    super("UserNotConfirmedException", "User is not confirmed.");
+  }
+}
+
 export class ResourceNotFoundError extends CognitoError {
   public constructor(message?: string) {
     super("ResourceNotFoundException", message ?? "Resource not found");

--- a/src/targets/adminInitiateAuth.ts
+++ b/src/targets/adminInitiateAuth.ts
@@ -7,6 +7,7 @@ import {
   InvalidPasswordError,
   NotAuthorizedError,
   UnsupportedError,
+  UserNotConfirmedException,
 } from "../errors";
 import { Services } from "../services";
 import { Target } from "./Target";
@@ -69,6 +70,10 @@ const adminUserPasswordAuthFlow = async (
 
   if (user.Password !== req.AuthParameters.PASSWORD) {
     throw new InvalidPasswordError();
+  }
+
+  if (user.UserStatus === "UNCONFIRMED") {
+    throw new UserNotConfirmedException();
   }
 
   const userGroups = await userPool.listUserGroupMembership(ctx, user);

--- a/src/targets/initiateAuth.ts
+++ b/src/targets/initiateAuth.ts
@@ -10,6 +10,7 @@ import {
   NotAuthorizedError,
   PasswordResetRequiredError,
   UnsupportedError,
+  UserNotConfirmedException,
 } from "../errors";
 import { Services, UserPoolService } from "../services";
 import { AppClient } from "../services/appClient";
@@ -179,6 +180,9 @@ const userPasswordAuthFlow = async (
   }
   if (user.Password !== req.AuthParameters.PASSWORD) {
     throw new InvalidPasswordError();
+  }
+  if (user.UserStatus === "UNCONFIRMED") {
+    throw new UserNotConfirmedException();
   }
 
   if (


### PR DESCRIPTION
PR for issue #122.

For reference, the error coming from "real" Cognito in this case is:
```
Error executing "AdminInitiateAuth" on "https://cognito-idp.eu-west-2.amazonaws.com"; AWS HTTP error: Client error: `POST https://cognito-idp.eu-west-2.amazonaws.com` resulted in a `400 Bad Request` response:
{"__type":"UserNotConfirmedException","message":"User is not confirmed."}
 UserNotConfirmedException (client): User is not confirmed. - {"__type":"UserNotConfirmedException","message":"User is not confirmed."}
 ```