### PR TITLE
fix(errorFormat): make exception format more consistent with real Cognito exceptions

### DIFF
--- a/integration-tests/aws-sdk/adminDeleteUser.test.ts
+++ b/integration-tests/aws-sdk/adminDeleteUser.test.ts
@@ -58,7 +58,7 @@ describe(
               UserPoolId: "test",
             })
             .promise()
-        ).rejects.toEqual(new UserNotFoundError("User does not exist"));
+        ).rejects.toEqual(new UserNotFoundError("User does not exist."));
       });
 
       it("deletes a user with an email address as a username", async () => {
@@ -109,7 +109,7 @@ describe(
               UserPoolId: "test",
             })
             .promise()
-        ).rejects.toEqual(new UserNotFoundError("User does not exist"));
+        ).rejects.toEqual(new UserNotFoundError("User does not exist."));
       });
     },
     {

--- a/integration-tests/aws-sdk/deleteUser.test.ts
+++ b/integration-tests/aws-sdk/deleteUser.test.ts
@@ -62,7 +62,7 @@ describe(
             UserPoolId: "test",
           })
           .promise()
-      ).rejects.toEqual(new UserNotFoundError("User does not exist"));
+      ).rejects.toEqual(new UserNotFoundError("User does not exist."));
     });
   })
 );

--- a/integration-tests/server.test.ts
+++ b/integration-tests/server.test.ts
@@ -69,7 +69,7 @@ describe("HTTP server", () => {
 
         expect(response.status).toEqual(500);
         expect(response.body).toEqual({
-          code: "CognitoLocal#Unsupported",
+          __type: "CognitoLocal#Unsupported",
           message: "Cognito Local unsupported feature: integration test",
         });
       });
@@ -95,7 +95,7 @@ describe("HTTP server", () => {
 
           expect(response.status).toEqual(400);
           expect(response.body).toEqual({
-            code: `CognitoLocal#${code}`,
+            __type: `${code}`,
             message,
           });
         }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -5,7 +5,7 @@ export class CognitoError extends Error {
 
   public constructor(code: string, message: string) {
     super(message);
-    this.code = `CognitoLocal#${code}`;
+    this.code = `${code}`;
   }
 }
 
@@ -16,7 +16,7 @@ export class NotAuthorizedError extends CognitoError {
 }
 
 export class UserNotFoundError extends CognitoError {
-  public constructor(message = "User not found") {
+  public constructor(message = "User not found.") {
     super("UserNotFoundException", message);
   }
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -107,14 +107,14 @@ export const createServer = (
 
           req.log.error(`Cognito Local unsupported feature: ${ex.message}`);
           res.status(500).json({
-            code: "CognitoLocal#Unsupported",
+            __type: "CognitoLocal#Unsupported",
             message: `Cognito Local unsupported feature: ${ex.message}`,
           });
           return;
         } else if (ex instanceof CognitoError) {
           req.log.warn(ex, `Error handling target: ${target}`);
           res.status(400).json({
-            code: ex.code,
+            __type: ex.code,
             message: ex.message,
           });
           return;

--- a/src/targets/adminGetUser.test.ts
+++ b/src/targets/adminGetUser.test.ts
@@ -47,6 +47,6 @@ describe("AdminGetUser target", () => {
         Username: existingUser.Username,
         UserPoolId: "test",
       })
-    ).rejects.toEqual(new UserNotFoundError("User does not exist"));
+    ).rejects.toEqual(new UserNotFoundError("User does not exist."));
   });
 });

--- a/src/targets/adminGetUser.ts
+++ b/src/targets/adminGetUser.ts
@@ -19,7 +19,7 @@ export const AdminGetUser =
     const userPool = await cognito.getUserPool(ctx, req.UserPoolId);
     const user = await userPool.getUserByUsername(ctx, req.Username);
     if (!user) {
-      throw new UserNotFoundError("User does not exist");
+      throw new UserNotFoundError("User does not exist.");
     }
 
     return {


### PR DESCRIPTION
This PR includes @HirokiItoga's fix from PR #304 plus a bit more, to make the messages more consistent with Cognito too.

I think this closes issue #315 (since this seems to affect both the Java and PHP SDKs).  

For reference, this is a real Cognito error from the PHP SDK with adminGetUser():
```
Error executing "AdminGetUser" on "https://cognito-idp.eu-west-2.amazonaws.com"; AWS HTTP error: Client error: `POST https://cognito-idp.eu-west-2.amazonaws.com` resulted in a `400 Bad Request` response:
{"__type":"UserNotFoundException","message":"User does not exist."}
UserNotFoundException (client): User does not exist. - {"__type":"UserNotFoundException","message":"User does not exist."}
```

I suspect all the real Cognito exception messages end with a full-stop / period, but I've only corrected the one I checked here.  Correcting the JSON field name and removing the leading CognitoLocal# prefix from the exception name (for real Cognito exceptions) is the more important element of the fix.