### PR TITLE
feat(confirmationCodes): add CODE environment variable to pre-define code

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,8 @@ For example:
 
 If a Custom Message lambda is configured, the output of the function invocation will be printed in the console too (verbosely!).
 
+By default, confirmation codes are randomly generated.  If set, the value assigned to the `CODE` environment variable will always be returned instead.
+
 ## Advanced
 
 ### Debugging Cognito Local

--- a/src/services/otp.ts
+++ b/src/services/otp.ts
@@ -1,4 +1,5 @@
 export const otp = (): string =>
+  process.env.CODE ??
   Math.floor(Math.random() * 999999)
     .toString()
     .padStart(6, "0");

--- a/src/targets/adminCreateUser.ts
+++ b/src/targets/adminCreateUser.ts
@@ -120,7 +120,7 @@ export const AdminCreateUser =
     const now = clock.get();
 
     const temporaryPassword =
-      req.TemporaryPassword ?? generator.new().slice(0, 6);
+      req.TemporaryPassword ?? process.env.CODE ?? generator.new().slice(0, 6);
 
     const isEmailUsername =
       config.UserPoolDefaults.UsernameAttributes?.includes("email");


### PR DESCRIPTION
Addresses #333.

Added the (optional) environment variable CODE to specify a confirmation code value which is always used.  I've not added a auto-test for this since I wasn't sure where it should go or how best to implement it.