### PR TITLE
fix: add openid-configuration endpoint

### DIFF
--- a/integration-tests/server.test.ts
+++ b/integration-tests/server.test.ts
@@ -126,4 +126,20 @@ describe("HTTP server", () => {
       });
     });
   });
+
+  describe("OpenId Configuration Endpoint", () => {
+    it("responds with open id configuration", async () => {
+      const server = createServer(jest.fn(), MockLogger as any);
+
+      const response = await supertest(server.application).get(
+        "/any-user-pool/.well-known/openid-configuration"
+      );
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual({
+        id_token_signing_alg_values_supported: ["RS256"],
+        jwks_uri: `http://localhost:9229/any-user-pool/.well-known/jwks.json`,
+        issuer: `http://localhost:9229/any-user-pool`,
+      });
+    });
+  });
 });

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -55,6 +55,14 @@ export const createServer = (
     });
   });
 
+  app.get("/:userPoolId/.well-known/openid-configuration", (req, res) => {
+    res.status(200).json({
+      id_token_signing_alg_values_supported: ["RS256"],
+      jwks_uri: `http://localhost:9229/${req.params.userPoolId}/.well-known/jwks.json`,
+      issuer: `http://localhost:9229/${req.params.userPoolId}`,
+    });
+  });
+
   app.get("/health", (req, res) => {
     res.status(200).json({ ok: true });
   });


### PR DESCRIPTION
Ref issue: https://github.com/jagregory/cognito-local/issues/348 

The cognito local package does not have an openid-configuration endpoint which is required for spring boot to find the jwks.json endpoint.

This PR adds the endpoint with the required information for spring boot to function