### PR TITLE
Add given_name and family_name attributes to id token

### DIFF
--- a/src/services/tokenGenerator.ts
+++ b/src/services/tokenGenerator.ts
@@ -162,6 +162,8 @@ export class JwtTokenGenerator implements TokenGenerator {
       email_verified: Boolean(
         attributeValue("email_verified", user.Attributes) ?? false
       ),
+      given_name: attributeValue("given_name", user.Attributes),
+      family_name: attributeValue("family_name", user.Attributes),
       event_id: eventId,
       iat: authTime,
       jti: uuid.v4(),


### PR DESCRIPTION
Fixes #360 

Adds the **given_name** and **family_name** attributes into the id token.

In our project making use of cognito-local (thanks for this) this addressed the problem for us.

Guidance would be helpful on whether this is indeed the correct fix and how the tests should be modified to prevent a future regression on these attributes (typescript not being my forte).