### PR TITLE
feat(signUp_verification_status): Sign up email/phone verification status fix

### DIFF
--- a/src/services/tokenGenerator.ts
+++ b/src/services/tokenGenerator.ts
@@ -160,7 +160,7 @@ export class JwtTokenGenerator implements TokenGenerator {
       auth_time: authTime,
       email: attributeValue("email", user.Attributes),
       email_verified: Boolean(
-        attributeValue("email_verified", user.Attributes) ?? false
+        "true" == attributeValue("email_verified", user.Attributes) ?? false
       ),
       event_id: eventId,
       iat: authTime,

--- a/src/targets/signUp.test.ts
+++ b/src/targets/signUp.test.ts
@@ -57,7 +57,7 @@ describe("SignUp target", () => {
     ).rejects.toBeInstanceOf(UsernameExistsError);
   });
 
-  it("saves a new user", async () => {
+  it("saves a new user with email", async () => {
     mockUserPoolService.getUserByUsername.mockResolvedValue(null);
 
     await signUp(TestContext, {
@@ -74,6 +74,41 @@ describe("SignUp target", () => {
           Value: expect.stringMatching(UUID),
         },
         { Name: "email", Value: "example@example.com" },
+        { Name: "email_verified", Value: "false" },
+      ],
+      Enabled: true,
+      Password: "pwd",
+      UserCreateDate: now,
+      UserLastModifiedDate: now,
+      UserStatus: "UNCONFIRMED",
+      Username: "user-supplied",
+      RefreshTokens: [],
+    });
+  });
+
+  it("saves a new user with email and phone_number", async () => {
+    mockUserPoolService.getUserByUsername.mockResolvedValue(null);
+
+    await signUp(TestContext, {
+      ClientId: "clientId",
+      Password: "pwd",
+      Username: "user-supplied",
+      UserAttributes: [
+        { Name: "email", Value: "example@example.com" },
+        { Name: "phone_number", Value: "0400000000" },
+      ],
+    });
+
+    expect(mockUserPoolService.saveUser).toHaveBeenCalledWith(TestContext, {
+      Attributes: [
+        {
+          Name: "sub",
+          Value: expect.stringMatching(UUID),
+        },
+        { Name: "email", Value: "example@example.com" },
+        { Name: "phone_number", Value: "0400000000" },
+        { Name: "email_verified", Value: "false" },
+        { Name: "phone_number_verified", Value: "false" },
       ],
       Enabled: true,
       Password: "pwd",
@@ -120,6 +155,7 @@ describe("SignUp target", () => {
         userAttributes: [
           { Name: "sub", Value: expect.stringMatching(UUID) },
           { Name: "email", Value: "example@example.com" },
+          { Name: "email_verified", Value: "false" },
         ],
         userPoolId: "test",
         username: "user-supplied",
@@ -206,6 +242,7 @@ describe("SignUp target", () => {
               userAttributes: [
                 { Name: "sub", Value: expect.stringMatching(UUID) },
                 { Name: "email", Value: "example@example.com" },
+                { Name: "email_verified", Value: "false" },
                 { Name: "cognito:user_status", Value: "CONFIRMED" },
               ],
               userPoolId: "test",
@@ -229,7 +266,10 @@ describe("SignUp target", () => {
               },
               Password: "pwd",
               Username: "user-supplied",
-              UserAttributes: [{ Name: "email", Value: "example@example.com" }],
+              UserAttributes: [
+                { Name: "email", Value: "example@example.com" },
+                { Name: "email_verified", Value: "false" },
+              ],
               ValidationData: [{ Name: "another", Value: "attribute" }],
             })
           ).rejects.toBeInstanceOf(UserLambdaValidationError);
@@ -466,6 +506,7 @@ describe("SignUp target", () => {
           Attributes: [
             { Name: "sub", Value: expect.stringMatching(UUID) },
             { Name: "email", Value: "example@example.com" },
+            { Name: "email_verified", Value: "false" },
           ],
           Enabled: true,
           Password: "pwd",
@@ -535,6 +576,7 @@ describe("SignUp target", () => {
           Attributes: [
             { Name: "sub", Value: expect.stringMatching(UUID) },
             { Name: "phone_number", Value: "0400000000" },
+            { Name: "phone_number_verified", Value: "false" },
           ],
           Enabled: true,
           Password: "pwd",
@@ -611,6 +653,8 @@ describe("SignUp target", () => {
             { Name: "sub", Value: expect.stringMatching(UUID) },
             { Name: "email", Value: "example@example.com" },
             { Name: "phone_number", Value: "0400000000" },
+            { Name: "email_verified", Value: "false" },
+            { Name: "phone_number_verified", Value: "false" },
           ],
           Enabled: true,
           Password: "pwd",
@@ -657,6 +701,7 @@ describe("SignUp target", () => {
           Attributes: [
             { Name: "sub", Value: expect.stringMatching(UUID) },
             { Name: "email", Value: "example@example.com" },
+            { Name: "email_verified", Value: "false" },
           ],
           Enabled: true,
           Password: "pwd",
@@ -719,6 +764,7 @@ describe("SignUp target", () => {
       Attributes: [
         { Name: "sub", Value: expect.stringMatching(UUID) },
         { Name: "email", Value: "example@example.com" },
+        { Name: "email_verified", Value: "false" },
       ],
       ConfirmationCode: "123456",
       Enabled: true,


### PR DESCRIPTION
When a user has an unverified email address or phone number allocated at signUp, real Cognito returns user attributes for email_verified = false and phone_number_verifed = false when doing a getUserByUsername.  When they don't have an email - the email_verified is not set either.  Similar for no phone number.  Cognito-local only returns the verification status once it's true.

I've partially implemented that, since I needed it.  It only works for users signed up with the email address as the primary identifier (I don't think cognito-local supports phone number only signups anyway?).

It's a bit hacky - I struggled to understand how the signup without pre-signup lambda was supposed to work - so it might need a bit of tidying up.  But i works for me now. 

