### PR TITLE
fix(initateAuth): update user after post auth lambda

### DIFF
--- a/src/targets/initiateAuth.ts
+++ b/src/targets/initiateAuth.ts
@@ -204,6 +204,7 @@ const userPasswordAuthFlow = async (
       username: user.Username,
       userPoolId: userPool.options.Id,
     });
+    user = await userPool.getUserByUsername(ctx, req.AuthParameters.USERNAME);
   }
 
   return verifyPasswordChallenge(


### PR DESCRIPTION
Get the latest user attributes after PostAuthentication is called.

If user attributes are updated within the PostAuthentication Lambda trigger process, these changes overwrite to old user attributes with generated tokens. To prevent this, it's necessary to get the latest user attribute before saving a new token.

Let me know if there is a specific guide for creating a pull request.