### PR TITLE
#393 add prefix dev for developer-only attributes

### DIFF
--- a/src/targets/createUserPool.ts
+++ b/src/targets/createUserPool.ts
@@ -56,7 +56,7 @@ const createSchemaAttributes = (
       const type = attr.AttributeDataType ?? "String";
 
       return {
-        Name: `custom:${attr.Name}`,
+        Name: `${attr.DeveloperOnlyAttribute ? "dev:" : ""}custom:${attr.Name}`,
         AttributeDataType: type,
         DeveloperOnlyAttribute: attr.DeveloperOnlyAttribute ?? false,
         Mutable: attr.Mutable ?? true,


### PR DESCRIPTION
- Fix #393 : Adding prefix `dev` on custom developer-only attributes