### PR TITLE
feat(config): allow for openid config to have altered hosts

### DIFF
--- a/src/server/defaults.ts
+++ b/src/server/defaults.ts
@@ -83,6 +83,8 @@ export const createDefaultServer = async (
     logger,
     {
       development: !!process.env.COGNITO_LOCAL_DEVMODE,
+      hostname: process.env.HOST || "localhost",
+      port: parseInt(process.env.PORT ?? "9229", 10),
     }
   );
 };

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -56,10 +56,13 @@ export const createServer = (
   });
 
   app.get("/:userPoolId/.well-known/openid-configuration", (req, res) => {
+    const host = process.env.WELL_KNOWN_CONFIG_HOST;
+    const port = process.env.WELL_KNOWN_CONFIG_PORT;
+
     res.status(200).json({
       id_token_signing_alg_values_supported: ["RS256"],
-      jwks_uri: `http://localhost:9229/${req.params.userPoolId}/.well-known/jwks.json`,
-      issuer: `http://localhost:9229/${req.params.userPoolId}`,
+      jwks_uri: `http://${host}:${port}/${req.params.userPoolId}/.well-known/jwks.json`,
+      issuer: `http://${host}:${port}/${req.params.userPoolId}`,
     });
   });
 


### PR DESCRIPTION
I encountered an issue when running the application in a Docker container. The well-known configuration was publishing a hardcoded localhost:9229 as its JWKS_URI. While this is generally acceptable, it becomes problematic if you need to change the ports or point to a different container. This PR addresses the issue by allowing the JWKS_URI to be altered, similar to how the issuer can be modified to reflect an address other than localhost:9229.