### PR TITLE
feat(api): support https

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,13 +309,20 @@ Before starting Cognito Local, create a config file if one doesn't already exist
 You can edit that `.cognito/config.json` and add any of the following settings:
 
 | Setting                                    | Type       | Default                 | Description                                                 |
-| ------------------------------------------ | ---------- | ----------------------- | ----------------------------------------------------------- |
+|--------------------------------------------|------------|-------------------------|-------------------------------------------------------------|
 | `LambdaClient`                             | `object`   |                         | Any setting you would pass to the AWS.Lambda Node.js client |
 | `LambdaClient.credentials.accessKeyId`     | `string`   | `local`                 |                                                             |
 | `LambdaClient.credentials.secretAccessKey` | `string`   | `local`                 |                                                             |
 | `LambdaClient.endpoint`                    | `string`   | `local`                 |                                                             |
 | `LambdaClient.region`                      | `string`   | `local`                 |                                                             |
 | `TokenConfig.IssuerDomain`                 | `string`   | `http://localhost:9229` | Issuer domain override                                      |
+| `ServerConfig`                             | `object`   |                         | Any setting you would pass to the Express server            |
+| `ServerConfig.hostname`                    | `string`   | `localhost`             | Hostname to listen on                                       |
+| `ServerConfig.port`                        | `number`   | `9229`                  | Port to listen on                                           |
+| `ServerConfig.https`                       | `boolean`  | `false`                 | Enable HTTPS                                                |
+| `ServerConfig.ca`                          | `string`   |                         | Path to the TLS CA file (ServerConfig.https must be true)   |
+| `ServerConfig.cert`                        | `string`   |                         | Path to the TLS Cert file (ServerConfig.https must be true) |
+| `ServerConfig.key`                         | `string`   |                         | Path to the TLS Key file (ServerConfig.https must be true)  |
 | `TriggerFunctions`                         | `object`   | `{}`                    | Trigger name to Function name mapping                       |
 | `TriggerFunctions.CustomMessage`           | `string`   |                         | CustomMessage local lambda function name                    |
 | `TriggerFunctions.PostAuthentication`      | `string`   |                         | PostAuthentication local lambda function name               |

--- a/integration-tests/aws-sdk/setup.ts
+++ b/integration-tests/aws-sdk/setup.ts
@@ -81,11 +81,13 @@ export const withCognitoSdk =
           DefaultConfig.TokenConfig
         ),
       });
-      const server = createServer(router, ctx.logger);
-      httpServer = await server.start({
+      const server = createServer(router, ctx.logger, {
+        development: false,
         hostname: "127.0.0.1",
+        https: false,
         port: 0,
       });
+      httpServer = await server.start();
 
       const address = httpServer.address();
       if (!address) {

--- a/src/bin/start.ts
+++ b/src/bin/start.ts
@@ -3,6 +3,7 @@
 import { createDefaultServer } from "../server";
 import Pino from "pino";
 import PinoPretty from "pino-pretty";
+import * as https from "https";
 
 const logger = Pino(
   {
@@ -18,13 +19,9 @@ const logger = Pino(
 );
 
 createDefaultServer(logger)
+  .then((server) => server.start())
   .then((server) => {
-    const hostname = process.env.HOST ?? "localhost";
-    const port = parseInt(process.env.PORT ?? "9229", 10);
-    return server.start({ hostname, port });
-  })
-  .then((httpServer) => {
-    const address = httpServer.address();
+    const address = server.address();
     if (!address) {
       throw new Error("Server started without address");
     }
@@ -33,7 +30,9 @@ createDefaultServer(logger)
         ? address
         : `${address.address}:${address.port}`;
 
-    logger.info(`Cognito Local running on http://${url}`);
+    const proto = server instanceof https.Server ? "https" : "http";
+
+    logger.info(`Cognito Local running on ${proto}://${url}`);
   })
   .catch((err) => {
     logger.error(err);

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -5,6 +5,7 @@ import { UserPool } from "../services/userPoolService";
 import { TokenConfig } from "../services/tokenGenerator";
 import mergeWith from "lodash.mergewith";
 import { KMSConfig } from "../services/crypto";
+import type { ServerOptions } from "./server";
 
 export type UserPoolDefaults = Omit<
   UserPool,
@@ -16,8 +17,12 @@ export interface Config {
   TriggerFunctions: FunctionConfig;
   UserPoolDefaults: UserPoolDefaults;
   KMSConfig?: AWS.KMS.ClientConfiguration & KMSConfig;
+  ServerConfig: ServerOptions;
   TokenConfig: TokenConfig;
 }
+
+const port = parseInt(process.env.PORT ?? "9229", 10);
+const hostname = process.env.HOST ?? "localhost";
 
 export const DefaultConfig: Config = {
   LambdaClient: {
@@ -32,8 +37,7 @@ export const DefaultConfig: Config = {
     UsernameAttributes: ["email"],
   },
   TokenConfig: {
-    // TODO: this needs to match the actual host/port we started the server on
-    IssuerDomain: "http://localhost:9229",
+    IssuerDomain: `http://${hostname}:${port}`,
   },
   KMSConfig: {
     credentials: {
@@ -41,6 +45,12 @@ export const DefaultConfig: Config = {
       secretAccessKey: "local",
     },
     region: "local",
+  },
+  ServerConfig: {
+    port,
+    hostname,
+    development: !!process.env.COGNITO_LOCAL_DEVMODE,
+    https: false,
   },
 };
 

--- a/src/server/defaults.ts
+++ b/src/server/defaults.ts
@@ -76,8 +76,6 @@ export const createDefaultServer = async (
       triggers,
     }),
     logger,
-    {
-      development: !!process.env.COGNITO_LOCAL_DEVMODE,
-    }
+    config.ServerConfig
   );
 };


### PR DESCRIPTION
Add a ServerConfig object to the config file where you can enable https, and provide paths to the ca/cert/key files.