### PR TITLE
fix: sub as username when using emails

### DIFF
--- a/integration-tests/aws-sdk/adminGetUser.test.ts
+++ b/integration-tests/aws-sdk/adminGetUser.test.ts
@@ -1,5 +1,7 @@
 import { ClockFake } from "../../src/__tests__/clockFake";
 import { withCognitoSdk } from "./setup";
+import { UUID } from "../../src/__tests__/patterns";
+import { attributeValue } from "../../src/services/userPoolService";
 
 const currentDate = new Date();
 const roundedDate = new Date(currentDate.getTime());
@@ -11,40 +13,114 @@ describe(
   "CognitoIdentityServiceProvider.adminGetUser",
   withCognitoSdk(
     (Cognito) => {
-      it("gets a user", async () => {
-        const client = Cognito();
+      describe("without any username attributes configured on the user pool", () => {
+        it("gets a user", async () => {
+          const client = Cognito();
 
-        const pool = await client
-          .createUserPool({
-            PoolName: "test",
-          })
-          .promise();
-        const userPoolId = pool.UserPool?.Id!!;
+          const pool = await client
+            .createUserPool({
+              PoolName: "test",
+            })
+            .promise();
+          const userPoolId = pool.UserPool?.Id!!;
 
-        // create the user
-        const createUserResult = await client
-          .adminCreateUser({
-            UserAttributes: [{ Name: "phone_number", Value: "0400000000" }],
-            Username: "abc",
-            UserPoolId: userPoolId,
-          })
-          .promise();
+          // create the user
+          const createUserResult = await client
+            .adminCreateUser({
+              UserAttributes: [{ Name: "phone_number", Value: "0400000000" }],
+              Username: "abc",
+              UserPoolId: userPoolId,
+            })
+            .promise();
 
-        // verify they exist
-        const result = await client
-          .adminGetUser({
-            Username: "abc",
-            UserPoolId: userPoolId,
-          })
-          .promise();
+          expect(createUserResult.User?.Username).toEqual("abc");
+          expect(
+            attributeValue("sub", createUserResult.User?.Attributes)
+          ).toEqual(expect.stringMatching(UUID));
 
-        expect(result).toEqual({
-          Enabled: true,
-          UserAttributes: createUserResult.User?.Attributes,
-          UserCreateDate: createUserResult.User?.UserCreateDate,
-          UserLastModifiedDate: createUserResult.User?.UserLastModifiedDate,
-          Username: createUserResult.User?.Username,
-          UserStatus: createUserResult.User?.UserStatus,
+          // verify they exist
+          const result = await client
+            .adminGetUser({
+              Username: "abc",
+              UserPoolId: userPoolId,
+            })
+            .promise();
+
+          expect(result).toEqual({
+            Enabled: true,
+            UserAttributes: createUserResult.User?.Attributes,
+            UserCreateDate: createUserResult.User?.UserCreateDate,
+            UserLastModifiedDate: createUserResult.User?.UserLastModifiedDate,
+            Username: createUserResult.User?.Username,
+            UserStatus: createUserResult.User?.UserStatus,
+          });
+        });
+      });
+
+      describe("with email configured as a username attribute on the user pool", () => {
+        it("gets a user", async () => {
+          const client = Cognito();
+
+          const pool = await client
+            .createUserPool({
+              PoolName: "test",
+              UsernameAttributes: ["email"],
+            })
+            .promise();
+          const userPoolId = pool.UserPool?.Id!!;
+
+          // create the user
+          const createUserResult = await client
+            .adminCreateUser({
+              UserAttributes: [{ Name: "phone_number", Value: "0400000000" }],
+              Username: "example@example.com",
+              UserPoolId: userPoolId,
+            })
+            .promise();
+
+          expect(createUserResult.User?.Username).toEqual(
+            expect.stringMatching(UUID)
+          );
+          expect(
+            attributeValue("sub", createUserResult.User?.Attributes)
+          ).toEqual(expect.stringMatching(UUID));
+
+          // verify they exist by email
+          let result = await client
+            .adminGetUser({
+              Username: "example@example.com",
+              UserPoolId: userPoolId,
+            })
+            .promise();
+
+          expect(result).toEqual({
+            Enabled: true,
+            UserAttributes: createUserResult.User?.Attributes,
+            UserCreateDate: createUserResult.User?.UserCreateDate,
+            UserLastModifiedDate: createUserResult.User?.UserLastModifiedDate,
+            Username: createUserResult.User?.Username,
+            UserStatus: createUserResult.User?.UserStatus,
+          });
+
+          // verify they exist by sub
+          result = await client
+            .adminGetUser({
+              Username: attributeValue(
+                "sub",
+                createUserResult.User?.Attributes
+              )!,
+              UserPoolId: userPoolId,
+            })
+            .promise();
+
+          expect(result).toEqual({
+            Enabled: true,
+            UserAttributes: createUserResult.User?.Attributes,
+            UserCreateDate: createUserResult.User?.UserCreateDate,
+            UserLastModifiedDate: createUserResult.User?.UserLastModifiedDate,
+            Username: createUserResult.User?.Username,
+            UserStatus: createUserResult.User?.UserStatus,
+          });
         });
       });
     },

--- a/integration-tests/aws-sdk/listUsers.test.ts
+++ b/integration-tests/aws-sdk/listUsers.test.ts
@@ -1,111 +1,156 @@
 import { withCognitoSdk } from "./setup";
+import { UUID } from "../../src/__tests__/patterns";
 
 describe(
   "CognitoIdentityServiceProvider.listUsers",
   withCognitoSdk((Cognito) => {
-    it("lists users", async () => {
-      const client = Cognito();
+    describe("without any username attributes configured on the user pool", () => {
+      it("lists users", async () => {
+        const client = Cognito();
 
-      const pool = await client
-        .createUserPool({
-          PoolName: "test",
-        })
-        .promise();
-      const userPoolId = pool.UserPool?.Id!!;
+        const pool = await client
+          .createUserPool({
+            PoolName: "test",
+          })
+          .promise();
+        const userPoolId = pool.UserPool?.Id!!;
 
-      const createUserResult = await client
-        .adminCreateUser({
-          UserAttributes: [{ Name: "phone_number", Value: "0400000000" }],
-          Username: "abc",
-          UserPoolId: userPoolId,
-        })
-        .promise();
-
-      const result = await client
-        .listUsers({
-          UserPoolId: userPoolId,
-        })
-        .promise();
-
-      expect(result).toEqual({
-        Users: [
-          {
-            Attributes: createUserResult.User?.Attributes,
-            Enabled: true,
-            UserCreateDate: createUserResult.User?.UserCreateDate,
-            UserLastModifiedDate: createUserResult.User?.UserLastModifiedDate,
-            UserStatus: "FORCE_CHANGE_PASSWORD",
+        const createUserResult = await client
+          .adminCreateUser({
+            UserAttributes: [{ Name: "phone_number", Value: "0400000000" }],
             Username: "abc",
-          },
-        ],
+            UserPoolId: userPoolId,
+          })
+          .promise();
+
+        const result = await client
+          .listUsers({
+            UserPoolId: userPoolId,
+          })
+          .promise();
+
+        expect(result).toEqual({
+          Users: [
+            {
+              Attributes: createUserResult.User?.Attributes,
+              Enabled: true,
+              UserCreateDate: createUserResult.User?.UserCreateDate,
+              UserLastModifiedDate: createUserResult.User?.UserLastModifiedDate,
+              UserStatus: "FORCE_CHANGE_PASSWORD",
+              Username: "abc",
+            },
+          ],
+        });
       });
-    });
 
-    it("filters users", async () => {
-      const client = Cognito();
+      it("filters users", async () => {
+        const client = Cognito();
 
-      const pool = await client
-        .createUserPool({
-          PoolName: "test",
-        })
-        .promise();
-      const userPoolId = pool.UserPool?.Id!!;
+        const pool = await client
+          .createUserPool({
+            PoolName: "test",
+          })
+          .promise();
+        const userPoolId = pool.UserPool?.Id!!;
 
-      await client
-        .adminCreateUser({
-          UserAttributes: [{ Name: "phone_number", Value: "0400000000" }],
-          Username: "abc1",
-          UserPoolId: userPoolId,
-        })
-        .promise();
+        await client
+          .adminCreateUser({
+            UserAttributes: [{ Name: "phone_number", Value: "0400000000" }],
+            Username: "abc1",
+            UserPoolId: userPoolId,
+          })
+          .promise();
 
-      const createUserResult2 = await client
-        .adminCreateUser({
-          UserAttributes: [{ Name: "phone_number", Value: "0500000000" }],
-          Username: "abc2",
-          UserPoolId: userPoolId,
-        })
-        .promise();
-
-      const result = await client
-        .listUsers({
-          UserPoolId: userPoolId,
-          Filter: 'phone_number ^= "05"',
-        })
-        .promise();
-
-      expect(result).toEqual({
-        Users: [
-          {
-            Attributes: createUserResult2.User?.Attributes,
-            Enabled: true,
-            UserCreateDate: createUserResult2.User?.UserCreateDate,
-            UserLastModifiedDate: createUserResult2.User?.UserLastModifiedDate,
-            UserStatus: "FORCE_CHANGE_PASSWORD",
+        const createUserResult2 = await client
+          .adminCreateUser({
+            UserAttributes: [{ Name: "phone_number", Value: "0500000000" }],
             Username: "abc2",
-          },
-        ],
+            UserPoolId: userPoolId,
+          })
+          .promise();
+
+        const result = await client
+          .listUsers({
+            UserPoolId: userPoolId,
+            Filter: 'phone_number ^= "05"',
+          })
+          .promise();
+
+        expect(result).toEqual({
+          Users: [
+            {
+              Attributes: createUserResult2.User?.Attributes,
+              Enabled: true,
+              UserCreateDate: createUserResult2.User?.UserCreateDate,
+              UserLastModifiedDate:
+                createUserResult2.User?.UserLastModifiedDate,
+              UserStatus: "FORCE_CHANGE_PASSWORD",
+              Username: "abc2",
+            },
+          ],
+        });
+      });
+
+      it("handles no users", async () => {
+        const client = Cognito();
+
+        const pool = await client
+          .createUserPool({
+            PoolName: "test",
+          })
+          .promise();
+        const userPoolId = pool.UserPool?.Id!!;
+
+        const result = await client
+          .listUsers({
+            UserPoolId: userPoolId,
+          })
+          .promise();
+
+        expect(result).toEqual({
+          Users: [],
+        });
       });
     });
 
-    it("handles no users", async () => {
-      const client = Cognito();
+    describe("with email configured as a username attribute on the user pool", () => {
+      it("lists users", async () => {
+        const client = Cognito();
 
-      const pool = await client
-        .createUserPool({
-          PoolName: "test",
-        })
-        .promise();
-      const userPoolId = pool.UserPool?.Id!!;
+        const pool = await client
+          .createUserPool({
+            PoolName: "test",
+            UsernameAttributes: ["email"],
+          })
+          .promise();
+        const userPoolId = pool.UserPool?.Id!!;
 
-      const result = await client
-        .listUsers({
-          UserPoolId: userPoolId,
-        })
-        .promise();
+        const createUserResult = await client
+          .adminCreateUser({
+            UserAttributes: [{ Name: "phone_number", Value: "0400000000" }],
+            Username: "example@example.com",
+            UserPoolId: userPoolId,
+          })
+          .promise();
 
-      expect(result).toEqual({
-        Users: [],
+        const result = await client
+          .listUsers({
+            UserPoolId: userPoolId,
+          })
+          .promise();
+
+        expect(result).toEqual({
+          Users: [
+            {
+              Attributes: createUserResult.User?.Attributes,
+              Enabled: true,
+              UserCreateDate: createUserResult.User?.UserCreateDate,
+              UserLastModifiedDate: createUserResult.User?.UserLastModifiedDate,
+              UserStatus: "FORCE_CHANGE_PASSWORD",
+              Username: expect.stringMatching(UUID),
+            },
+          ],
+        });
       });
     });
   })

--- a/setupTests.ts
+++ b/setupTests.ts
@@ -23,9 +23,6 @@ declare global {
   }
 }
 
-// "Payload": {"version":0,"callerContext":{"awsSdkVersion":"2.953.0","clientId":"clientId"},"region":"local","userPoolId":"userPoolId","triggerSource":"UserMigration_Authentication","request":{"userAttributes":{},"validationData":{},"password":"password"},"response":{},"userName":"username"}
-// "Payload": {"version":0,"callerContext":{"awsSdkVersion":"2.953.0","clientId":"clientId"},"region":"local","userPoolId":"userPoolId","triggerSource":"UserMigration_Authentication","request":{"userAttributes":{},"validationData":{},"password":"password"},"response":{},"userName":"username"}
-
 export {};
 
 afterEach(() => {

--- a/src/targets/adminCreateUser.test.ts
+++ b/src/targets/adminCreateUser.test.ts
@@ -30,7 +30,7 @@ describe("AdminCreateUser target", () => {
     });
   });
 
-  it("saves a new user with a provided temporary password", async () => {
+  it("saves a new user with a provided temporary password when the user pool has no username attributes", async () => {
     await adminCreateUser(TestContext, {
       TemporaryPassword: "pwd",
       UserAttributes: [
@@ -56,6 +56,38 @@ describe("AdminCreateUser target", () => {
       UserLastModifiedDate: originalDate,
       UserStatus: "FORCE_CHANGE_PASSWORD",
       Username: "user-supplied",
+      RefreshTokens: [],
+    });
+  });
+
+  it("saves a new user with a provided temporary password when the user pool has no username attributes", async () => {
+    mockUserPoolService.options.UsernameAttributes = ["email"];
+
+    await adminCreateUser(TestContext, {
+      TemporaryPassword: "pwd",
+      UserAttributes: [
+        { Name: "email", Value: "example@example.com" },
+        { Name: "phone_number", Value: "0400000000" },
+      ],
+      Username: "example@example.com",
+      UserPoolId: "test",
+    });
+
+    expect(mockUserPoolService.saveUser).toHaveBeenCalledWith(TestContext, {
+      Attributes: [
+        {
+          Name: "sub",
+          Value: expect.stringMatching(UUID),
+        },
+        { Name: "email", Value: "example@example.com" },
+        { Name: "phone_number", Value: "0400000000" },
+      ],
+      Enabled: true,
+      Password: "pwd",
+      UserCreateDate: originalDate,
+      UserLastModifiedDate: originalDate,
+      UserStatus: "FORCE_CHANGE_PASSWORD",
+      Username: expect.stringMatching(UUID),
       RefreshTokens: [],
     });
   });


### PR DESCRIPTION
If a User Pool is configured with email as a UsernameAttribute then:

1. The Username field in requests to create users should be validated as an email address
2. The User's `sub` field is used as their username attribute and is returned from any get or list actions

If a User Pool doesn't have a UsernameAttribute set, then the Username from the create actions will be used as the User's Username.

BREAKING CHANGE: It's possible that users may have been stored with their email address as their Username in the cognito-local database, this was incorrect and shouldn't have happened. You may need to recreate any users who were incorrectly saved with their email address as their username.

Fixes #102 #334
Closes #335 