### PR TITLE
OpenID config JSON should reflect host and port of the running server

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -61,10 +61,13 @@ export const createServer = (
   });
 
   app.get("/:userPoolId/.well-known/openid-configuration", (req, res) => {
+    const hostname = options.hostname;
+    const port = options.port;
+    const userPoolId = req.params.userPoolId;
     res.status(200).json({
       id_token_signing_alg_values_supported: ["RS256"],
-      jwks_uri: `http://localhost:9229/${req.params.userPoolId}/.well-known/jwks.json`,
-      issuer: `http://localhost:9229/${req.params.userPoolId}`,
+      jwks_uri: `http://${hostname}:${port}/${userPoolId}/.well-known/jwks.json`,
+      issuer: `http://${hostname}:${port}/${userPoolId}`,
     });
   });
 


### PR DESCRIPTION
The `host:port` pair in the OpenID config JSON is hardcoded to `localhost:9229`, but the `cognito-local` server can be started with different parameters. This, for example, might cause a mismatch between the token's `iss` claim (which defaults to `http://0.0.0.0:9229/<userPoolId>`) and what is returned in the OpenID config JSON.