### PR TITLE
Change initiateAuth check order

### DIFF
--- a/src/targets/initiateAuth.ts
+++ b/src/targets/initiateAuth.ts
@@ -172,14 +172,14 @@ const userPasswordAuthFlow = async (
   if (!user) {
     throw new NotAuthorizedError();
   }
+  if (user.Password !== req.AuthParameters.PASSWORD) {
+    throw new InvalidPasswordError();
+  }
   if (user.UserStatus === "RESET_REQUIRED") {
     throw new PasswordResetRequiredError();
   }
   if (user.UserStatus === "FORCE_CHANGE_PASSWORD") {
     return newPasswordChallenge(user);
-  }
-  if (user.Password !== req.AuthParameters.PASSWORD) {
-    throw new InvalidPasswordError();
   }
   if (user.UserStatus === "UNCONFIRMED") {
     throw new UserNotConfirmedException();


### PR DESCRIPTION
It doesn't make sense to let the user change or reset the password if the password provided is incorrect