### PR TITLE
feat: implement client_credentials support

### DIFF
--- a/integration-tests/server.test.ts
+++ b/integration-tests/server.test.ts
@@ -1,7 +1,10 @@
 import supertest from "supertest";
 import { describe, expect, it, vi } from "vitest";
 import { createServer } from "../src";
+import { newMockCognitoService } from "../src/__tests__/mockCognitoService";
 import { MockLogger } from "../src/__tests__/mockLogger";
+import { newMockTokenGenerator } from "../src/__tests__/mockTokenGenerator";
+import * as TDB from "../src/__tests__/testDataBuilder";
 import {
   CodeMismatchError,
   CognitoError,
@@ -139,6 +142,298 @@ describe("HTTP server", () => {
         jwks_uri: `http://localhost:9229/any-user-pool/.well-known/jwks.json`,
         issuer: `http://localhost:9229/any-user-pool`,
       });
+    });
+  });
+
+  describe("OAuth2 token endpoint", () => {
+    const appClient = TDB.appClient({
+      ClientSecret: "correct-secret",
+      AllowedOAuthFlows: ["client_credentials"],
+      AllowedOAuthScopes: ["api/read", "api/write"],
+      UserPoolId: "test-pool",
+    });
+
+    const makeServices = (overrides?: {
+      appClient?: typeof appClient | null;
+    }) => {
+      const mockCognito = newMockCognitoService();
+      mockCognito.getAppClient.mockResolvedValue(
+        overrides?.appClient !== undefined ? overrides.appClient : appClient,
+      );
+      const mockTokenGenerator = newMockTokenGenerator();
+      mockTokenGenerator.generateClientCredentials.mockResolvedValue({
+        AccessToken: "signed.jwt.token",
+        ExpiresIn: 3600,
+        TokenType: "Bearer" as const,
+      });
+      return { cognito: mockCognito, tokenGenerator: mockTokenGenerator };
+    };
+
+    it("returns 501 when no services are configured", async () => {
+      const server = createServer(vi.fn(), MockLogger as any, {});
+
+      const response = await supertest(server.application)
+        .post("/test-pool/oauth2/token")
+        .type("form")
+        .send({ grant_type: "client_credentials" });
+
+      expect(response.status).toEqual(501);
+      expect(response.body.error).toEqual("server_error");
+    });
+
+    it("returns 400 for unsupported grant_type", async () => {
+      const server = createServer(
+        vi.fn(),
+        MockLogger as any,
+        {},
+        makeServices(),
+      );
+
+      const response = await supertest(server.application)
+        .post("/test-pool/oauth2/token")
+        .type("form")
+        .send({ grant_type: "authorization_code" });
+
+      expect(response.status).toEqual(400);
+      expect(response.body.error).toEqual("unsupported_grant_type");
+    });
+
+    it("returns 401 when credentials are missing", async () => {
+      const server = createServer(
+        vi.fn(),
+        MockLogger as any,
+        {},
+        makeServices(),
+      );
+
+      const response = await supertest(server.application)
+        .post("/test-pool/oauth2/token")
+        .type("form")
+        .send({ grant_type: "client_credentials" });
+
+      expect(response.status).toEqual(401);
+      expect(response.body.error).toEqual("invalid_client");
+    });
+
+    it("returns 401 when client is not found", async () => {
+      const server = createServer(
+        vi.fn(),
+        MockLogger as any,
+        {},
+        makeServices({ appClient: null }),
+      );
+
+      const response = await supertest(server.application)
+        .post("/test-pool/oauth2/token")
+        .type("form")
+        .send({
+          grant_type: "client_credentials",
+          client_id: "unknown",
+          client_secret: "x",
+        });
+
+      expect(response.status).toEqual(401);
+      expect(response.body.error).toEqual("invalid_client");
+    });
+
+    it("returns 401 for wrong client secret via body params", async () => {
+      const server = createServer(
+        vi.fn(),
+        MockLogger as any,
+        {},
+        makeServices(),
+      );
+
+      const response = await supertest(server.application)
+        .post("/test-pool/oauth2/token")
+        .type("form")
+        .send({
+          grant_type: "client_credentials",
+          client_id: appClient.ClientId,
+          client_secret: "wrong",
+        });
+
+      expect(response.status).toEqual(401);
+      expect(response.body.error).toEqual("invalid_client");
+    });
+
+    it("returns 401 for wrong client secret via Basic auth header", async () => {
+      const server = createServer(
+        vi.fn(),
+        MockLogger as any,
+        {},
+        makeServices(),
+      );
+      const credentials = Buffer.from(
+        `${appClient.ClientId}:wrong-secret`,
+      ).toString("base64");
+
+      const response = await supertest(server.application)
+        .post("/test-pool/oauth2/token")
+        .type("form")
+        .set("Authorization", `Basic ${credentials}`)
+        .send({ grant_type: "client_credentials" });
+
+      expect(response.status).toEqual(401);
+      expect(response.body.error).toEqual("invalid_client");
+    });
+
+    it("returns 401 when Basic auth header has no colon separator", async () => {
+      const server = createServer(
+        vi.fn(),
+        MockLogger as any,
+        {},
+        makeServices(),
+      );
+      const malformed = Buffer.from("noclientidsecret").toString("base64");
+
+      const response = await supertest(server.application)
+        .post("/test-pool/oauth2/token")
+        .type("form")
+        .set("Authorization", `Basic ${malformed}`)
+        .send({ grant_type: "client_credentials" });
+
+      expect(response.status).toEqual(401);
+      expect(response.body.error).toEqual("invalid_client");
+    });
+
+    it("returns 401 when client belongs to a different user pool", async () => {
+      const poolAClient = TDB.appClient({
+        ClientSecret: "correct-secret",
+        AllowedOAuthFlows: ["client_credentials"],
+        AllowedOAuthScopes: ["api/read"],
+        UserPoolId: "pool-a",
+      });
+      const server = createServer(
+        vi.fn(),
+        MockLogger as any,
+        {},
+        makeServices({ appClient: poolAClient }),
+      );
+
+      const response = await supertest(server.application)
+        .post("/pool-b/oauth2/token")
+        .type("form")
+        .send({
+          grant_type: "client_credentials",
+          client_id: poolAClient.ClientId,
+          client_secret: "correct-secret",
+        });
+
+      expect(response.status).toEqual(401);
+      expect(response.body.error).toEqual("invalid_client");
+    });
+
+    it("returns 400 when client_credentials flow is not allowed", async () => {
+      const restrictedClient = TDB.appClient({
+        ClientSecret: "correct-secret",
+        AllowedOAuthFlows: ["implicit"],
+        AllowedOAuthScopes: ["api/read"],
+        UserPoolId: "test-pool",
+      });
+      const server = createServer(
+        vi.fn(),
+        MockLogger as any,
+        {},
+        makeServices({ appClient: restrictedClient }),
+      );
+
+      const response = await supertest(server.application)
+        .post("/test-pool/oauth2/token")
+        .type("form")
+        .send({
+          grant_type: "client_credentials",
+          client_id: restrictedClient.ClientId,
+          client_secret: "correct-secret",
+        });
+
+      expect(response.status).toEqual(400);
+      expect(response.body.error).toEqual("unauthorized_client");
+    });
+
+    it("returns 400 for an unrecognised scope", async () => {
+      const server = createServer(
+        vi.fn(),
+        MockLogger as any,
+        {},
+        makeServices(),
+      );
+
+      const response = await supertest(server.application)
+        .post("/test-pool/oauth2/token")
+        .type("form")
+        .send({
+          grant_type: "client_credentials",
+          client_id: appClient.ClientId,
+          client_secret: "correct-secret",
+          scope: "api/admin",
+        });
+
+      expect(response.status).toEqual(400);
+      expect(response.body.error).toEqual("invalid_scope");
+    });
+
+    it("issues a token via body params", async () => {
+      const services = makeServices();
+      const server = createServer(vi.fn(), MockLogger as any, {}, services);
+
+      const response = await supertest(server.application)
+        .post("/test-pool/oauth2/token")
+        .type("form")
+        .send({
+          grant_type: "client_credentials",
+          client_id: appClient.ClientId,
+          client_secret: "correct-secret",
+          scope: "api/read",
+        });
+
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual({
+        access_token: "signed.jwt.token",
+        expires_in: 3600,
+        token_type: "Bearer",
+      });
+      expect(
+        services.tokenGenerator.generateClientCredentials,
+      ).toHaveBeenCalledWith(expect.anything(), appClient, ["api/read"]);
+    });
+
+    it("issues a token via Basic auth header", async () => {
+      const services = makeServices();
+      const server = createServer(vi.fn(), MockLogger as any, {}, services);
+      const credentials = Buffer.from(
+        `${appClient.ClientId}:correct-secret`,
+      ).toString("base64");
+
+      const response = await supertest(server.application)
+        .post("/test-pool/oauth2/token")
+        .type("form")
+        .set("Authorization", `Basic ${credentials}`)
+        .send({ grant_type: "client_credentials" });
+
+      expect(response.status).toEqual(200);
+      expect(response.body.access_token).toEqual("signed.jwt.token");
+    });
+
+    it("uses all allowed scopes when no scope param is provided", async () => {
+      const services = makeServices();
+      const server = createServer(vi.fn(), MockLogger as any, {}, services);
+
+      await supertest(server.application)
+        .post("/test-pool/oauth2/token")
+        .type("form")
+        .send({
+          grant_type: "client_credentials",
+          client_id: appClient.ClientId,
+          client_secret: "correct-secret",
+        });
+
+      expect(
+        services.tokenGenerator.generateClientCredentials,
+      ).toHaveBeenCalledWith(expect.anything(), appClient, [
+        "api/read",
+        "api/write",
+      ]);
     });
   });
 });

--- a/src/__tests__/mockTokenGenerator.ts
+++ b/src/__tests__/mockTokenGenerator.ts
@@ -3,4 +3,5 @@ import type { TokenGenerator } from "../services/tokenGenerator";
 
 export const newMockTokenGenerator = (): MockedObject<TokenGenerator> => ({
   generate: vi.fn(),
+  generateClientCredentials: vi.fn(),
 });

--- a/src/server/defaults.ts
+++ b/src/server/defaults.ts
@@ -58,6 +58,12 @@ export const createDefaultServer = async (
     new CryptoService(config.KMSConfig),
   );
 
+  const tokenGenerator = new JwtTokenGenerator(
+    clock,
+    triggers,
+    config.TokenConfig,
+  );
+
   return createServer(
     Router({
       clock,
@@ -68,14 +74,11 @@ export const createDefaultServer = async (
         new MessageDeliveryService(new ConsoleMessageSender()),
       ),
       otp,
-      tokenGenerator: new JwtTokenGenerator(
-        clock,
-        triggers,
-        config.TokenConfig,
-      ),
+      tokenGenerator,
       triggers,
     }),
     logger,
     config.ServerConfig,
+    { cognito: cognitoClient, tokenGenerator },
   );
 };

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -9,6 +9,7 @@ import Pino from "pino-http";
 import * as uuid from "uuid";
 import { CognitoError, UnsupportedError } from "../errors";
 import PublicKey from "../keys/cognitoLocal.public.json";
+import type { Services } from "../services";
 import type { Router } from "./Router";
 
 export type ServerOptions = {
@@ -30,6 +31,7 @@ export const createServer = (
   router: Router,
   logger: Logger,
   options: ServerOptions,
+  services?: Pick<Services, "cognito" | "tokenGenerator">,
 ): Server => {
   const pino = Pino({
     logger,
@@ -71,6 +73,131 @@ export const createServer = (
 
   app.get("/health", (_req, res) => {
     res.status(200).json({ ok: true });
+  });
+
+  app.use(
+    "/:userPoolId/oauth2/token",
+    bodyParser.urlencoded({ extended: false }),
+  );
+
+  app.post("/:userPoolId/oauth2/token", async (req, res) => {
+    if (!services) {
+      res.status(501).json({
+        error: "server_error",
+        error_description: "OAuth not configured",
+      });
+      return;
+    }
+
+    const {
+      grant_type,
+      client_id: bodyClientId,
+      client_secret: bodyClientSecret,
+      scope: scopeParam,
+    } = req.body;
+
+    if (grant_type !== "client_credentials") {
+      res.status(400).json({ error: "unsupported_grant_type" });
+      return;
+    }
+
+    let clientId: string | undefined;
+    let clientSecret: string | undefined;
+
+    const authHeader = req.headers.authorization;
+    if (typeof authHeader === "string" && authHeader.startsWith("Basic ")) {
+      const decoded = Buffer.from(authHeader.slice(6), "base64").toString(
+        "utf-8",
+      );
+      const colonIdx = decoded.indexOf(":");
+      if (colonIdx !== -1) {
+        clientId = decoded.slice(0, colonIdx);
+        clientSecret = decoded.slice(colonIdx + 1);
+      }
+    } else {
+      clientId = bodyClientId;
+      clientSecret = bodyClientSecret;
+    }
+
+    if (!clientId || !clientSecret) {
+      res.status(401).json({
+        error: "invalid_client",
+        error_description: "Missing credentials",
+      });
+      return;
+    }
+
+    const ctx = { logger: req.log };
+    const appClient = await services.cognito.getAppClient(ctx, clientId);
+
+    if (!appClient) {
+      res.status(401).json({
+        error: "invalid_client",
+        error_description: "Client not found",
+      });
+      return;
+    }
+
+    if (appClient.UserPoolId !== req.params.userPoolId) {
+      res.status(401).json({
+        error: "invalid_client",
+        error_description: "Client not found",
+      });
+      return;
+    }
+
+    if (!appClient.ClientSecret || appClient.ClientSecret !== clientSecret) {
+      res.status(401).json({
+        error: "invalid_client",
+        error_description: "Invalid client credentials",
+      });
+      return;
+    }
+
+    if (!appClient.AllowedOAuthFlows?.includes("client_credentials")) {
+      res.status(400).json({ error: "unauthorized_client" });
+      return;
+    }
+
+    const allowedScopes = appClient.AllowedOAuthScopes ?? [];
+    const requestedScopes =
+      typeof scopeParam === "string" && scopeParam.length > 0
+        ? scopeParam.split(" ").filter(Boolean)
+        : allowedScopes;
+
+    for (const scope of requestedScopes) {
+      if (!allowedScopes.includes(scope)) {
+        res.status(400).json({
+          error: "invalid_scope",
+          error_description: `Unknown scope: ${scope}`,
+        });
+        return;
+      }
+    }
+
+    let result: Awaited<
+      ReturnType<typeof services.tokenGenerator.generateClientCredentials>
+    >;
+    try {
+      result = await services.tokenGenerator.generateClientCredentials(
+        ctx,
+        appClient,
+        requestedScopes,
+      );
+    } catch (ex) {
+      req.log.error(ex, "Failed to generate client credentials token");
+      res.status(500).json({
+        error: "server_error",
+        error_description: "Failed to generate token",
+      });
+      return;
+    }
+
+    res.status(200).json({
+      access_token: result.AccessToken,
+      expires_in: result.ExpiresIn,
+      token_type: result.TokenType,
+    });
   });
 
   app.post("/", (req, res) => {

--- a/src/services/tokenGenerator.test.ts
+++ b/src/services/tokenGenerator.test.ts
@@ -372,6 +372,91 @@ describe("JwtTokenGenerator", () => {
     });
   });
 
+  describe("generateClientCredentials", () => {
+    beforeEach(() => {
+      mockTriggers.enabled.mockReturnValue(false);
+    });
+
+    it("generates an access token with machine-token claims and no user fields", async () => {
+      const userPoolClient = TDB.appClient({
+        ClientSecret: "supersecret",
+        AllowedOAuthFlows: ["client_credentials"],
+        AllowedOAuthScopes: ["api/read"],
+      });
+
+      const result = await tokenGenerator.generateClientCredentials(
+        TestContext,
+        userPoolClient,
+        ["api/read"],
+      );
+
+      expect(result.TokenType).toBe("Bearer");
+      expect(result.ExpiresIn).toBe(3600);
+
+      const decoded = jwt.decode(result.AccessToken) as Record<string, unknown>;
+      expect(decoded).toMatchObject({
+        sub: userPoolClient.ClientId,
+        client_id: userPoolClient.ClientId,
+        token_use: "access",
+        scope: "api/read",
+        iss: `http://example.com/${userPoolClient.UserPoolId}`,
+        iat: Math.floor(originalDate.getTime() / 1000),
+        exp: Math.floor(originalDate.getTime() / 1000) + 3600,
+        jti: expect.stringMatching(UUID),
+      });
+
+      expect(decoded).not.toHaveProperty("username");
+      expect(decoded).not.toHaveProperty("auth_time");
+      expect(decoded).not.toHaveProperty("event_id");
+      expect(decoded).not.toHaveProperty("cognito:groups");
+    });
+
+    it("joins multiple scopes space-separated in the token", async () => {
+      const userPoolClient = TDB.appClient();
+      const result = await tokenGenerator.generateClientCredentials(
+        TestContext,
+        userPoolClient,
+        ["api/read", "api/write"],
+      );
+      expect(
+        (jwt.decode(result.AccessToken) as Record<string, unknown>).scope,
+      ).toBe("api/read api/write");
+    });
+
+    it("uses AccessTokenValidity and units when configured", async () => {
+      const userPoolClient = TDB.appClient({
+        AccessTokenValidity: 30,
+        TokenValidityUnits: { AccessToken: "minutes" },
+      });
+
+      const result = await tokenGenerator.generateClientCredentials(
+        TestContext,
+        userPoolClient,
+        [],
+      );
+
+      expect(result.ExpiresIn).toBe(30 * ONE_MINUTE);
+      expect(
+        (jwt.decode(result.AccessToken) as Record<string, unknown>).exp,
+      ).toBe(Math.floor(originalDate.getTime() / 1000) + 30 * ONE_MINUTE);
+    });
+
+    it("defaults to 3600 seconds when no AccessTokenValidity is set", async () => {
+      const userPoolClient = TDB.appClient({
+        AccessTokenValidity: undefined,
+        TokenValidityUnits: undefined,
+      });
+
+      const result = await tokenGenerator.generateClientCredentials(
+        TestContext,
+        userPoolClient,
+        [],
+      );
+
+      expect(result.ExpiresIn).toBe(3600);
+    });
+  });
+
   describe("groups", () => {
     it("does not include a cognito:groups claim if the user has no groups", async () => {
       mockTriggers.enabled.mockReturnValue(false);

--- a/src/services/tokenGenerator.ts
+++ b/src/services/tokenGenerator.ts
@@ -90,6 +90,12 @@ export interface Tokens {
   readonly RefreshToken: string;
 }
 
+export interface ClientCredentialsTokens {
+  readonly AccessToken: string;
+  readonly ExpiresIn: number;
+  readonly TokenType: "Bearer";
+}
+
 export interface TokenGenerator {
   generate(
     ctx: Context,
@@ -104,6 +110,12 @@ export interface TokenGenerator {
       | "NewPasswordChallenge"
       | "RefreshTokens",
   ): Promise<Tokens>;
+
+  generateClientCredentials(
+    ctx: Context,
+    userPoolClient: AppClient,
+    scopes: string[],
+  ): Promise<ClientCredentialsTokens>;
 }
 
 function assertUnitAnyCase(unit: string): asserts unit is UnitAnyCase {
@@ -111,6 +123,27 @@ function assertUnitAnyCase(unit: string): asserts unit is UnitAnyCase {
     throw new Error(`Invalid unit: ${unit}`);
   }
 }
+
+const toExpiresInSeconds = (
+  duration: number | undefined,
+  unit: TimeUnitsType | undefined,
+): number => {
+  if (duration === undefined) {
+    return 3600; // default 1 hour
+  }
+  switch (unit ?? "hours") {
+    case "seconds":
+      return duration;
+    case "minutes":
+      return duration * 60;
+    case "hours":
+      return duration * 3600;
+    case "days":
+      return duration * 86400;
+    default:
+      return 3600;
+  }
+};
 
 const formatExpiration = (
   duration: number | undefined,
@@ -253,5 +286,36 @@ export class JwtTokenGenerator implements TokenGenerator {
         } satisfies SignOptions,
       ),
     };
+  }
+
+  public async generateClientCredentials(
+    _ctx: Context,
+    userPoolClient: AppClient,
+    scopes: string[],
+  ): Promise<ClientCredentialsTokens> {
+    const now = Math.floor(this.clock.get().getTime() / 1000);
+    const issuer = `${this.tokenConfig.IssuerDomain}/${userPoolClient.UserPoolId}`;
+    const expiresIn = toExpiresInSeconds(
+      userPoolClient.AccessTokenValidity,
+      userPoolClient.TokenValidityUnits?.AccessToken,
+    );
+
+    const payload: RawToken = {
+      client_id: userPoolClient.ClientId,
+      exp: now + expiresIn,
+      iat: now,
+      jti: uuid.v4(),
+      scope: scopes.join(" "),
+      sub: userPoolClient.ClientId,
+      token_use: "access",
+    };
+
+    const AccessToken = jwt.sign(payload, PrivateKey.pem, {
+      algorithm: "RS256",
+      issuer,
+      keyid: "CognitoLocal",
+    } satisfies SignOptions);
+
+    return { AccessToken, ExpiresIn: expiresIn, TokenType: "Bearer" };
   }
 }


### PR DESCRIPTION
This adds support for the client_credentials flow for machine-to-machine communication. 

This PR doesn't include support for adding resource servers yet. It will naively provide scopes for any resource server for that client app.

I added tokenGenerator in to `services` but let me know if you think it should go elsewhere.

More information on the token endpoint:
https://docs.aws.amazon.com/cognito/latest/developerguide/token-endpoint.html